### PR TITLE
fix: install dependencies before Vercel build

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -81,6 +81,9 @@ jobs:
           test -n "$VERCEL_PROJECT_ID" || { echo "Missing VERCEL_PROJECT_ID production secret."; exit 1; }
           test -n "$VERCEL_TOKEN" || { echo "Missing VERCEL_TOKEN production secret."; exit 1; }
 
+      - name: Install application dependencies
+        run: npm ci
+
       - name: Install pinned Vercel CLI
         run: npm install --global "vercel@$VERCEL_CLI_VERSION"
 


### PR DESCRIPTION
## Summary

- Describe what changed and why.

## Verification

- [ ] Unit tests pass locally
- [ ] Production build passes locally
- [ ] No credentials, tokens, or private keys are included
- [ ] Firebase rules or data-model changes are documented

## Release impact

- [ ] No production release required
- [ ] Include this change in the next `PRD/vX.Y.Z` release
