### PR TITLE
fix: run Vercel CLI from repository root

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -54,9 +54,6 @@ jobs:
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}
-    defaults:
-      run:
-        working-directory: wongsakorn127-byjaimesjames
     env:
       VERCEL_CLI_VERSION: "54.14.2"
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -80,9 +77,6 @@ jobs:
           test -n "$VERCEL_ORG_ID" || { echo "Missing VERCEL_ORG_ID production secret."; exit 1; }
           test -n "$VERCEL_PROJECT_ID" || { echo "Missing VERCEL_PROJECT_ID production secret."; exit 1; }
           test -n "$VERCEL_TOKEN" || { echo "Missing VERCEL_TOKEN production secret."; exit 1; }
-
-      - name: Install application dependencies
-        run: npm ci
 
       - name: Install pinned Vercel CLI
         run: npm install --global "vercel@$VERCEL_CLI_VERSION"


### PR DESCRIPTION
## Summary

- Describe what changed and why.

## Verification

- [ ] Unit tests pass locally
- [ ] Production build passes locally
- [ ] No credentials, tokens, or private keys are included
- [ ] Firebase rules or data-model changes are documented

## Release impact

- [ ] No production release required
- [ ] Include this change in the next `PRD/vX.Y.Z` release
