### PR TITLE
fix: server render query-dependent routes

### DIFF
--- a/wongsakorn127-byjaimesjames/src/app/app.routes.server.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.server.spec.ts
@@ -1,0 +1,23 @@
+import { RenderMode } from '@angular/ssr';
+import { serverRoutes } from './app.routes.server';
+
+describe('serverRoutes', () => {
+  it('server-renders routes whose behavior depends on query parameters', () => {
+    const renderModes = new Map(
+      serverRoutes.map(route => [route.path, route.renderMode]),
+    );
+
+    expect(renderModes.get('auth')).toBe(RenderMode.Server);
+    expect(renderModes.get('nosy-game')).toBe(RenderMode.Server);
+    expect(renderModes.get('kinglee-game')).toBe(RenderMode.Server);
+  });
+
+  it('keeps static landing routes prerendered', () => {
+    const renderModes = new Map(
+      serverRoutes.map(route => [route.path, route.renderMode]),
+    );
+
+    expect(renderModes.get('')).toBe(RenderMode.Prerender);
+    expect(renderModes.get('home')).toBe(RenderMode.Prerender);
+  });
+});

--- a/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
@@ -2,8 +2,27 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
-    path: '**',
+    path: '',
     renderMode: RenderMode.Prerender
   },
-  
+  {
+    path: 'home',
+    renderMode: RenderMode.Prerender
+  },
+  {
+    path: 'auth',
+    renderMode: RenderMode.Server
+  },
+  {
+    path: 'nosy-game',
+    renderMode: RenderMode.Server
+  },
+  {
+    path: 'kinglee-game',
+    renderMode: RenderMode.Server
+  },
+  {
+    path: '**',
+    renderMode: RenderMode.Server
+  }
 ];


### PR DESCRIPTION
## Summary

- Describe what changed and why.

## Verification

- [ ] Unit tests pass locally
- [ ] Production build passes locally
- [ ] No credentials, tokens, or private keys are included
- [ ] Firebase rules or data-model changes are documented

## Release impact

- [ ] No production release required
- [ ] Include this change in the next `PRD/vX.Y.Z` release
