### PR TITLE
fix: route Vercel deep links to CSR shell

### DIFF
--- a/wongsakorn127-byjaimesjames/scripts/vercel-routing.test.mjs
+++ b/wongsakorn127-byjaimesjames/scripts/vercel-routing.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const config = JSON.parse(
+  await readFile(new URL('../vercel.json', import.meta.url), 'utf8'),
+);
+
+test('interactive routes use the Angular client-rendered shell on Vercel', () => {
+  const rewrites = new Map(
+    config.rewrites.map(rewrite => [rewrite.source, rewrite.destination]),
+  );
+
+  assert.equal(rewrites.get('/auth'), '/index.csr.html');
+  assert.equal(rewrites.get('/nosy-game'), '/index.csr.html');
+  assert.equal(rewrites.get('/kinglee-game'), '/index.csr.html');
+});

--- a/wongsakorn127-byjaimesjames/vercel.json
+++ b/wongsakorn127-byjaimesjames/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/auth",
+      "destination": "/index.csr.html"
+    },
+    {
+      "source": "/nosy-game",
+      "destination": "/index.csr.html"
+    },
+    {
+      "source": "/kinglee-game",
+      "destination": "/index.csr.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Describe what changed and why.

## Verification

- [ ] Unit tests pass locally
- [ ] Production build passes locally
- [ ] No credentials, tokens, or private keys are included
- [ ] Firebase rules or data-model changes are documented

## Release impact

- [ ] No production release required
- [ ] Include this change in the next `PRD/vX.Y.Z` release
