### PR TITLE
fix: make Firebase deploy tooling deterministic

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -61,7 +61,6 @@ jobs:
       name: production
       url: ${{ steps.deploy.outputs.url }}
     env:
-      FIREBASE_CLI_VERSION: "15.22.0"
       FIREBASE_PROJECT_ID: "wongsakorn127-byjaimesjames"
       FIREBASE_SERVICE_ACCOUNT: ${{ vars.FIREBASE_SERVICE_ACCOUNT }}
       FIREBASE_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
@@ -101,22 +100,24 @@ jobs:
           echo "production_url=$production_url" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to Google Cloud without a service account key
-        id: google-auth
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
         with:
           workload_identity_provider: ${{ vars.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.FIREBASE_SERVICE_ACCOUNT }}
           create_credentials_file: true
+          export_environment_variables: true
 
-      - name: Install pinned Firebase CLI
-        run: npm install --global "firebase-tools@$FIREBASE_CLI_VERSION"
+      - name: Install locked Firebase CLI
+        working-directory: wongsakorn127-byjaimesjames
+        run: npm ci --ignore-scripts
 
       - name: Deploy tested Firestore rules
         working-directory: wongsakorn127-byjaimesjames
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google-auth.outputs.credentials_file_path }}
-          GOOGLE_CLOUD_PROJECT: ${{ env.FIREBASE_PROJECT_ID }}
-        run: firebase deploy --only firestore:rules --project="$FIREBASE_PROJECT_ID" --non-interactive
+        shell: bash
+        run: |
+          test -n "$GOOGLE_APPLICATION_CREDENTIALS" || { echo "Missing GOOGLE_APPLICATION_CREDENTIALS."; exit 1; }
+          test -f "$GOOGLE_APPLICATION_CREDENTIALS" || { echo "Google credentials file is missing."; exit 1; }
+          npx --no-install firebase deploy --only firestore:rules --project="$FIREBASE_PROJECT_ID" --non-interactive
 
       - name: Install pinned Vercel CLI
         run: npm install --global "vercel@$VERCEL_CLI_VERSION"

--- a/wongsakorn127-byjaimesjames/package-lock.json
+++ b/wongsakorn127-byjaimesjames/package-lock.json
@@ -37,7 +37,7 @@
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
         "@types/node": "^18.18.0",
-        "firebase-tools": "^15.22.0",
+        "firebase-tools": "15.22.0",
         "jasmine-core": "~5.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",

--- a/wongsakorn127-byjaimesjames/package.json
+++ b/wongsakorn127-byjaimesjames/package.json
@@ -49,7 +49,7 @@
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^18.18.0",
-    "firebase-tools": "^15.22.0",
+    "firebase-tools": "15.22.0",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",


### PR DESCRIPTION
## Summary

- Describe what changed and why.

## Verification

- [ ] Unit tests pass locally
- [ ] Production build passes locally
- [ ] No credentials, tokens, or private keys are included
- [ ] Firebase rules or data-model changes are documented

## Release impact

- [ ] No production release required
- [ ] Include this change in the next `PRD/vX.Y.Z` release
