### PR TITLE
fix(WSK127-003): stop referrer from blocking Google profile photos

### DIFF
--- a/wongsakorn127-byjaimesjames/src/app/core/layout/head/head.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/head/head.component.html
@@ -23,6 +23,8 @@
           >
           <img
             [src]="userProfile ? userProfile : 'profile-1.png'"
+            referrerpolicy="no-referrer"
+            (error)="onProfileImageError($event)"
             class="border-2 border-light-bg rounded-full"
             />
           </button>

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/head/head.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/head/head.component.spec.ts
@@ -20,4 +20,18 @@ describe('HeadComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('falls back to the default profile image when the photo fails to load', () => {
+    const img = document.createElement('img');
+    img.src = 'https://lh3.googleusercontent.com/a/broken-photo';
+    component.onProfileImageError({ target: img } as unknown as Event);
+    expect(img.src.endsWith('profile-1.png')).toBeTrue();
+  });
+
+  it('does not loop when the default profile image itself errors', () => {
+    const img = document.createElement('img');
+    img.src = 'profile-1.png';
+    component.onProfileImageError({ target: img } as unknown as Event);
+    expect(img.src.endsWith('profile-1.png')).toBeTrue();
+  });
 });

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/head/head.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/head/head.component.ts
@@ -50,6 +50,14 @@ export class HeadComponent implements OnInit {
 
       });
   }
+  onProfileImageError(event: Event): void {
+    const img = event.target as HTMLImageElement;
+    if (img.src.endsWith('profile-1.png')) {
+      return;
+    }
+    img.src = 'profile-1.png';
+  }
+
   logOutBtn() {
     this.toggle = false
     this.authService.logout().then(() => {


### PR DESCRIPTION
## Summary
- Google's photo CDN can reject the profile photo request based on the `Referer` header sent from an unfamiliar origin (e.g. `localhost`), which presented like a CORS failure.
- Add `referrerpolicy="no-referrer"` to the profile `<img>` so no referrer is sent, on local dev and production alike.
- Add an `(error)` fallback to the default `profile-1.png` avatar if the photo still fails to load for any other reason.

Closes #28

## Test plan
- [x] `npm run test:ci` — 52/52 passing (2 new tests for the fallback behavior)
- [x] `npm run build` — passing
- [x] Verified live in browser: forced a broken photo URL and confirmed `referrerPolicy` is `no-referrer` and the image falls back to `profile-1.png` automatically