### PR TITLE
fix(WSK127-004): use a Firebase CI token to deploy Firestore rules

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -53,7 +53,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write
     outputs:
       deployment_url: ${{ steps.deploy.outputs.url }}
       production_url: ${{ steps.config.outputs.production_url }}
@@ -62,8 +61,7 @@ jobs:
       url: ${{ steps.deploy.outputs.url }}
     env:
       FIREBASE_PROJECT_ID: "wongsakorn127-byjaimesjames"
-      FIREBASE_SERVICE_ACCOUNT: ${{ vars.FIREBASE_SERVICE_ACCOUNT }}
-      FIREBASE_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
       PRODUCTION_URL: ${{ vars.PRODUCTION_URL }}
       VERCEL_CLI_VERSION: "54.14.2"
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -85,8 +83,7 @@ jobs:
         id: config
         shell: bash
         run: |
-          test -n "$FIREBASE_SERVICE_ACCOUNT" || { echo "Missing FIREBASE_SERVICE_ACCOUNT production variable."; exit 1; }
-          test -n "$FIREBASE_WORKLOAD_IDENTITY_PROVIDER" || { echo "Missing FIREBASE_WORKLOAD_IDENTITY_PROVIDER production variable."; exit 1; }
+          test -n "$FIREBASE_TOKEN" || { echo "Missing FIREBASE_TOKEN production secret."; exit 1; }
           test -n "$PRODUCTION_URL" || { echo "Missing PRODUCTION_URL production variable."; exit 1; }
           test -n "$VERCEL_ORG_ID" || { echo "Missing VERCEL_ORG_ID production secret."; exit 1; }
           test -n "$VERCEL_PROJECT_ID" || { echo "Missing VERCEL_PROJECT_ID production secret."; exit 1; }
@@ -99,14 +96,6 @@ jobs:
           esac
           echo "production_url=$production_url" >> "$GITHUB_OUTPUT"
 
-      - name: Authenticate to Google Cloud without a service account key
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
-        with:
-          workload_identity_provider: ${{ vars.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.FIREBASE_SERVICE_ACCOUNT }}
-          create_credentials_file: true
-          export_environment_variables: true
-
       - name: Install locked Firebase CLI
         working-directory: wongsakorn127-byjaimesjames
         run: npm ci --ignore-scripts
@@ -115,9 +104,7 @@ jobs:
         working-directory: wongsakorn127-byjaimesjames
         shell: bash
         run: |
-          test -n "$GOOGLE_APPLICATION_CREDENTIALS" || { echo "Missing GOOGLE_APPLICATION_CREDENTIALS."; exit 1; }
-          test -f "$GOOGLE_APPLICATION_CREDENTIALS" || { echo "Google credentials file is missing."; exit 1; }
-          npx --no-install firebase deploy --only firestore:rules --project="$FIREBASE_PROJECT_ID" --non-interactive
+          npx --no-install firebase deploy --only firestore:rules --project="$FIREBASE_PROJECT_ID" --non-interactive --token "$FIREBASE_TOKEN"
 
       - name: Install pinned Vercel CLI
         run: npm install --global "vercel@$VERCEL_CLI_VERSION"
@@ -187,7 +174,7 @@ jobs:
           {
             echo "## Production release ${{ needs.validate-release.outputs.version }}"
             echo ""
-            echo "- Firestore rules deployed with keyless GitHub OIDC authentication"
+            echo "- Firestore rules deployed using a Firebase CI token"
             echo "- Public production URL: ${PRODUCTION_URL}"
             echo "- Vercel deployment: ${DEPLOYMENT_URL}"
             echo "- Public route smoke tests passed"


### PR DESCRIPTION
## Summary
- The last 3 production releases (PRD/v1.0.11, v1.0.12, v1.0.13) all failed at "Deploy tested Firestore rules" with `Failed to authenticate, have you run firebase login?`, even though the Workload Identity Federation auth step reported success.
- Root cause: `google-github-actions/auth@v3` (keyless WIF) produces an `external_account`-type credentials file, which `firebase-tools` does not reliably support for the `deploy` command.
- Switch the Firestore rules deploy step to a `FIREBASE_TOKEN` GitHub secret instead — the auth method `firebase-tools` has always supported. Removed the now-unused WIF auth step and its config checks.

**Trade-off**: this replaces keyless WIF auth with a long-lived Firebase CI token secret for this one step. Worth revisiting once `firebase-tools` has solid WIF support for `deploy`.

**Requires action before merging/tagging**: the `FIREBASE_TOKEN` repo secret must be set (generate via `firebase login:ci` and `gh secret set FIREBASE_TOKEN`, done by the repo owner).

Closes #30

## Test plan
- [x] YAML syntax validated
- [x] `npm run test:ci` — 50/50 passing (no app code touched)
- [ ] First real production tag push after `FIREBASE_TOKEN` is set will confirm the deploy step succeeds