### PR TITLE
fix(WSK127-005): group @angular-devkit packages with @angular updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       angular:
         patterns:
           - "@angular/*"
+          - "@angular-devkit/*"
       firebase:
         patterns:
           - "firebase"


### PR DESCRIPTION
## Summary
- Dependabot's `angular` group only matched `@angular/*`, so `@angular/compiler-cli` and `@angular-devkit/build-angular` were bumped in separate PRs.
- Each PR alone left a broken peer dependency: bumping `@angular/*` alone left `@angular-devkit/build-angular` requiring the old `@angular/compiler-cli`, and vice versa. Confirmed by mirrored `ERESOLVE` errors in both PRs' CI logs (#6 and #9).
- Add `@angular-devkit/*` to the `angular` group so they bump together atomically in one PR.

Config-only change, no app code affected.

Closes #32

## Test plan
- [x] YAML syntax validated
- [ ] Next Dependabot Angular bump PR passes CI with both packages moved together