### PR TITLE
feat(WSK127-002): gate registration behind privacy/terms consent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# Wongsakorn127 — Working Rules
+
+Personal UX/UI design space (Angular 21 SSR) for custom mini-games (Nosy Game, Kinglee Game, Spin It, ...). Owner: JaimesJames. These rules are durable and apply to every future task in this repo — follow them without being reminded.
+
+## 1. Ticket-first
+
+- No code changes without a GitHub Issue first. This is the hard requirement — the issue
+  itself (title + AC) is what gates work starting, and only needs `repo` scope, which has
+  never broken on this machine.
+  - Title convention (existing, keep using it): `WSK127-XXX [Category] Short title` e.g. `WSK127-010 [UxUi/FE] Custom color panel for the wheel`
+- Every ticket must have QA-able Acceptance Criteria (checklist or Given/When/Then) in the issue body before work starts.
+- **Approval gate**: draft the ticket (title + AC) and show it in chat. Do not create the GitHub issue, and do not start implementation, until the user explicitly approves the AC in chat.
+- **Kanban board is best-effort, not a gate**: also try to add/move the issue on
+  https://github.com/users/JaimesJames/projects/1 (`Wongsakorn127byJaimesJames`, project
+  number 1; columns `Todo` → `In Progress` → `Done`). The `project` scope on this
+  machine's `gh` token has repeatedly reverted on its own — if adding/moving the card
+  fails for that reason, skip it and keep working; do not block on `gh auth refresh` loops.
+  Move to `Done` only after merge + doc update, when the board is reachable.
+
+## 2. Tests + CI gate, no silent commits
+
+- Every change ships with a test (unit at minimum; e2e/manual-verified for UI flows that can't be unit tested).
+- Before proposing any commit: run `npm run test:ci` and `npm run build` inside `wongsakorn127-byjaimesjames/` locally, and confirm they pass.
+- **Never commit without explicit per-commit confirmation from the user.** Show the diff/summary, wait for the user to say to proceed, then commit.
+- One branch per ticket: `feature/WSK127-XXX-slug`. No direct commits to `main`. Open a PR, wait for CI (`ci.yml`) to go green, before it's mergeable.
+- Commit messages: Conventional Commits, referencing the ticket id, e.g. `feat(WSK127-010): add wheel color picker`.
+
+## 3. Docs/spec folder — must stay aligned with kanban
+
+- `wongsakorn127-byjaimesjames/docs/tickets/<WSK127-XXX>-slug.md` per ticket: AC, design notes/decisions, status, link back to the issue.
+- `wongsakorn127-byjaimesjames/docs/status-board.md`: single mirror of the kanban board (Todo / In Progress / Done). Update this file in the same commit whenever a ticket's status changes on the board — the two must never drift.
+
+## 4. UI structural pattern
+
+- Every page must compose through one shared shell providing three fixed regions: **Wongsakorn brand/title spot, navigation, profile menu**. Do not let a feature page build its own header/nav.
+- Current state (gap, not yet built): `core/layout/head` only has login/profile-menu; `core/layout/navigator` only has the bottom-sheet game grid. There is no title/brand spot yet — building the shared shell component is itself a ticket, not an ad-hoc change.
+- Document the shell's layout contract (region positions, responsive behavior) in `wongsakorn127-byjaimesjames/docs/` before implementing it.
+
+## 5. Language
+
+- Chat conversation with the user stays in whatever language they use (Thai is fine).
+- Everything produced as an artifact must be English only: GitHub issues/tickets, commit messages, branch names, code, comments, UI copy/strings, and docs under `docs/`.
+
+## Notes
+
+- `gh` active account on this machine is `JaimesJames` (admin on this repo). The `project`
+  scope needed for kanban board access has repeatedly reverted on its own — see the
+  best-effort note in Rule 1.
+- Production releases (`release-production.yml`) deploy Firestore rules using the
+  `FIREBASE_TOKEN` secret (fixed in WSK127-004; Workload Identity Federation was not
+  reliably supported by `firebase-tools deploy` and broke 3 releases in a row).
+- Fixed in WSK127-005: Dependabot's `angular` group now includes `@angular-devkit/*`
+  alongside `@angular/*` so they bump together instead of conflicting.

--- a/wongsakorn127-byjaimesjames/docs/status-board.md
+++ b/wongsakorn127-byjaimesjames/docs/status-board.md
@@ -1,0 +1,17 @@
+# Status board (mirror of kanban)
+
+Kanban: https://github.com/users/JaimesJames/projects/1
+
+Update this file in the same commit whenever a ticket's status changes on the board.
+
+## Todo
+_(none)_
+
+## In Progress
+- WSK127-002 [UxUi/FE] Inform privacy policy before register
+
+## Done
+- WSK127-001 [Full] Nosy Game first spin
+- WSK127-003 [Bug] Google profile photo fails to load
+- WSK127-004 [Bug] Production release pipeline fails to deploy Firestore rules
+- WSK127-005 [Bug] Dependabot angular PRs conflict with each other

--- a/wongsakorn127-byjaimesjames/docs/tickets/README.md
+++ b/wongsakorn127-byjaimesjames/docs/tickets/README.md
@@ -1,0 +1,22 @@
+# Ticket specs
+
+One file per ticket: `<WSK127-XXX>-slug.md`. Created when a ticket is approved in chat, kept in sync with the kanban card until `Done`.
+
+## Template
+
+```markdown
+# WSK127-XXX [Category] Title
+
+- Kanban: https://github.com/JaimesJames/Wongsakorn127/issues/<n>
+- Status: Todo | In Progress | Done
+- Branch: feature/WSK127-XXX-slug
+
+## Acceptance Criteria
+- [ ] ...
+
+## Design notes / decisions
+- ...
+
+## Test plan
+- ...
+```

--- a/wongsakorn127-byjaimesjames/docs/tickets/WSK127-002-privacy-consent.md
+++ b/wongsakorn127-byjaimesjames/docs/tickets/WSK127-002-privacy-consent.md
@@ -1,0 +1,24 @@
+# WSK127-002 [UxUi/FE] Inform privacy policy before register
+
+- Kanban: https://github.com/JaimesJames/Wongsakorn127/issues/2
+- Status: In Progress
+- Branch: feature/WSK127-002-privacy-consent
+
+## Acceptance Criteria
+- [x] Register form shows one checkbox, unchecked by default: "I agree to the Privacy Policy and Terms & Conditions", with inline clickable links.
+- [x] The "register" submit button stays disabled while the checkbox is unchecked.
+- [x] In register mode (`isLogin === false`), the "Continue with Google" button stays disabled while the checkbox is unchecked.
+- [x] In login mode (`isLogin === true`), the Google button behaves as before (not gated).
+- [x] Checking the checkbox enables the register submit button, and (in register mode) the Google button.
+- [x] Clicking the Privacy Policy / Terms & Conditions links opens a new route (`/legal`) showing a placeholder page clearly marked "Placeholder - final copy TBD".
+- [x] The auth page footer (visible in both login and register mode) shows links to Privacy Policy and Terms & Conditions.
+- [x] Switching between Login and Register mode resets the checkbox to unchecked.
+- [x] Unit tests cover: submit disabled when unchecked; submit enabled when checked; Google button gated only in register mode; checkbox resets on mode toggle.
+
+## Design notes / decisions
+- Scope combines Privacy Policy and Terms & Conditions behind a single checkbox and a single placeholder route (`/legal`) — no separate pages, per product decision.
+- Google sign-in is gated only while in register mode, since the same button also serves as the login path for existing accounts.
+
+## Test plan
+- `npm run test:ci` — unit tests for `AuthComponent` and `LegalComponent`.
+- Manual verification in browser: register mode checkbox/button gating, mode-toggle reset, `/legal` placeholder route.

--- a/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
@@ -26,6 +26,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Client
   },
   {
+    path: 'legal',
+    renderMode: RenderMode.Client
+  },
+  {
     path: '**',
     renderMode: RenderMode.Client
   }

--- a/wongsakorn127-byjaimesjames/src/app/app.routes.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.ts
@@ -30,5 +30,9 @@ export const routes: Routes = [
     path: 'spin-it',
     loadComponent: () => import('./feature/spinitGame/page/spinitgame/spinitgame.component').then(m => m.SpinitgameComponent),
     canActivate: [ParamsGuard]
+  },
+  {
+    path: 'legal',
+    loadComponent: () => import('./feature/legal/page/legal.component').then(m => m.LegalComponent),
   }
 ];

--- a/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.html
@@ -76,8 +76,18 @@
                   >
                   * Passwords do not match.
                 </div>
+                <label class="flex items-center gap-2 text-sm text-start px-5 text-text-bglight">
+                  <input type="checkbox" formControlName="agreeToTerms" />
+                  <span>
+                    I agree to the
+                    <a [routerLink]="['/legal']" target="_blank" class="underline">Privacy Policy</a>
+                    and
+                    <a [routerLink]="['/legal']" target="_blank" class="underline">Terms &amp; Conditions</a>
+                  </span>
+                </label>
                 <button
                   type="submit"
+                  [disabled]="registerForm.invalid"
         [ngClass]="{
           'opacity-40 font-semibold bg-transparent border-2 border-dark-bg text-dark-bg':
             registerForm.invalid,
@@ -146,6 +156,8 @@
                 <hr />
                 <button
                   (click)="loginWithGoogle()"
+                  [disabled]="isGoogleButtonDisabled"
+                  [ngClass]="{'opacity-40': isGoogleButtonDisabled}"
                   class="flex items-center justify-center gap-3 border-2 border-gray-300 rounded-full w-full p-3 hover:bg-gray-100 hover:cursor-pointer transition text-text-bglight"
                   >
                   <img
@@ -171,6 +183,11 @@
                           />
                         </button>
                       </a>
+                      <footer class="mt-10 text-xs opacity-60 text-text-bglight">
+                        <a [routerLink]="['/legal']" target="_blank" class="underline">Privacy Policy</a>
+                        &middot;
+                        <a [routerLink]="['/legal']" target="_blank" class="underline">Terms &amp; Conditions</a>
+                      </footer>
                     </div>
                   }
                 </main>

--- a/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.spec.ts
@@ -20,4 +20,44 @@ describe('AuthComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('disables register submission until terms are accepted', () => {
+    component.isLogin = false;
+    component.registerForm.patchValue({
+      username: 'tester',
+      email: 'tester@example.com',
+      password: 'secret1',
+      confirmPassword: 'secret1'
+    });
+    expect(component.registerForm.valid).toBeFalse();
+
+    component.registerForm.get('agreeToTerms')?.setValue(true);
+    expect(component.registerForm.valid).toBeTrue();
+  });
+
+  it('gates the Google button only while registering without consent', () => {
+    component.isLogin = true;
+    expect(component.isGoogleButtonDisabled).toBeFalse();
+
+    component.isLogin = false;
+    component.registerForm.get('agreeToTerms')?.setValue(false);
+    expect(component.isGoogleButtonDisabled).toBeTrue();
+
+    component.registerForm.get('agreeToTerms')?.setValue(true);
+    expect(component.isGoogleButtonDisabled).toBeFalse();
+  });
+
+  it('resets the consent checkbox when toggling modes', () => {
+    component.registerForm.get('agreeToTerms')?.setValue(true);
+    component.toggleMode();
+    expect(component.registerForm.get('agreeToTerms')?.value).toBeFalse();
+  });
+
+  it('does not call the auth service when Google sign-in is gated', async () => {
+    const authServiceSpy = spyOn((component as any).authService, 'loginWithGoogle');
+    component.isLogin = false;
+    component.registerForm.get('agreeToTerms')?.setValue(false);
+    await component.loginWithGoogle();
+    expect(authServiceSpy).not.toHaveBeenCalled();
+  });
 });

--- a/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { AbstractControl, FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators, ValidationErrors } from '@angular/forms';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { InitialLoadingComponent } from '../../share/components/loading/initialLoading.component';
 import { CreditBadgeComponent } from '../../share/components/badges/creditBadge/creditBadge.component';
 import { AuthService } from '../../adapters/angular/services/auth/auth.service';
@@ -11,7 +11,7 @@ import { getFirebaseUserMessage } from '../../../infrastructure/firebase/firebas
 @Component({
   selector: 'app-auth',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, InitialLoadingComponent, CreditBadgeComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterLink, InitialLoadingComponent, CreditBadgeComponent],
   templateUrl: './auth.component.html',
   styleUrls: ['./auth.component.css'],
 })
@@ -35,7 +35,8 @@ export class AuthComponent implements OnInit {
       username: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       password: ['', [Validators.required, Validators.minLength(6)]],
-      confirmPassword: ['', Validators.required]
+      confirmPassword: ['', Validators.required],
+      agreeToTerms: [false, Validators.requiredTrue]
     },
       { validators: this.passwordMatchValidator }
     );
@@ -99,7 +100,14 @@ export class AuthComponent implements OnInit {
     }
   }
 
+  get isGoogleButtonDisabled(): boolean {
+    return !this.isLogin && !this.registerForm.get('agreeToTerms')?.value;
+  }
+
   async loginWithGoogle() {
+    if (this.isGoogleButtonDisabled) {
+      return;
+    }
     try {
       const user = await this.authService.loginWithGoogle()
       if (user) {
@@ -113,5 +121,6 @@ export class AuthComponent implements OnInit {
   toggleMode() {
     this.isLogin = !this.isLogin
     this.Message = ''
+    this.registerForm.get('agreeToTerms')?.setValue(false)
   }
 }

--- a/wongsakorn127-byjaimesjames/src/app/feature/legal/page/legal.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/legal/page/legal.component.html
@@ -1,0 +1,7 @@
+<main
+  class="w-screen max-w-[720px] m-auto min-h-screen flex flex-col justify-center text-center p-10 gap-4"
+>
+  <h2 class="text-3xl font-semibold text-text-bglight">Privacy Policy &amp; Terms &amp; Conditions</h2>
+  <p class="text-sm opacity-70">Placeholder - final copy TBD</p>
+  <a [routerLink]="['/auth']" class="underline hover:cursor-pointer mt-6">Back</a>
+</main>

--- a/wongsakorn127-byjaimesjames/src/app/feature/legal/page/legal.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/legal/page/legal.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { LegalComponent } from './legal.component';
+
+describe('LegalComponent', () => {
+  let component: LegalComponent;
+  let fixture: ComponentFixture<LegalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LegalComponent],
+      providers: [provideRouter([])]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LegalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the placeholder notice', () => {
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Placeholder - final copy TBD');
+  });
+});

--- a/wongsakorn127-byjaimesjames/src/app/feature/legal/page/legal.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/legal/page/legal.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-legal',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './legal.component.html',
+  styleUrl: './legal.component.css'
+})
+export class LegalComponent {
+}


### PR DESCRIPTION
## Summary
- Add a required consent checkbox to the register form: "I agree to the Privacy Policy and Terms & Conditions", with inline links.
- Gate the register submit button and (in register mode only) the "Continue with Google" button behind that consent, since Google sign-in also creates new accounts.
- Add a placeholder `/legal` route until real Privacy Policy / Terms & Conditions copy is ready.
- Checkbox resets whenever the user switches between Login and Register mode.
- Also lands the working-rules setup agreed with the user in chat: `CLAUDE.md`, per-ticket spec docs under `docs/tickets/`, and `docs/status-board.md` mirroring the kanban board.

Closes #2

## Test plan
- [x] `npm run test:ci` — 58/58 passing (new tests for `AuthComponent` consent gating and `LegalComponent`)
- [x] `npm run build` — passing
- [x] Verified live in browser: register/Google buttons disabled until consent checked, footer links work, `/legal` placeholder renders, checkbox resets on mode toggle