### PR TITLE
feat(WSK127-006): add shared shell for title/nav/profile consistency

### DIFF
--- a/wongsakorn127-byjaimesjames/docs/shell-layout-contract.md
+++ b/wongsakorn127-byjaimesjames/docs/shell-layout-contract.md
@@ -1,0 +1,48 @@
+# Shell layout contract
+
+`ShellComponent` (`src/app/core/layout/shell/`) owns the title/brand region every page
+must use instead of placing `CreditBadgeComponent` and top spacing by hand.
+
+## Regions
+
+1. **Title spot** — `CreditBadgeComponent` ("Wongsakorn127 / by JaimesJames"), rendered
+   by the shell at a fixed position.
+2. **Content** — projected via `<ng-content>`, positioned by the `contentAlign` input.
+3. **Navigation** and **profile menu** stay global (`NavigatorComponent`, `HeadComponent`
+   in `app.component.html`), unchanged by this ticket — they already render on every
+   route.
+
+## Inputs
+
+- `isLight: boolean` (default `false`) — passed through to `CreditBadgeComponent` for
+  light/dark text color, matching each page's background.
+- `contentAlign: 'top' | 'center'` (default `'top'`):
+  - `'top'`: content starts directly below the title, offset by `pt-40` (matches the
+    space the global fixed header/profile button needs).
+  - `'center'`: content is vertically centered in the space below the title (used by
+    `auth`, whose login/register forms are a centered-form pattern, not a top-anchored
+    game screen).
+
+## Usage
+
+```html
+<main class="w-screen h-screen ... flex flex-col">
+  <app-shell [isLight]="true">
+    <!-- page content -->
+  </app-shell>
+</main>
+```
+
+The page's own `<main>` keeps its background, overflow, and decorative elements — the
+shell only standardizes the title position and content alignment.
+
+## Known exception: `spinit-page`
+
+`spinitgame` has a fixed-height (`100dvh`, `overflow: hidden`), pixel-budgeted layout
+(the wheel's size is computed from remaining viewport height). Matching the other pages'
+full `pt-40` + `p-10` top offset (200px) did not fit this page's budget — the wheel hit
+its minimum size and content still clipped. This page keeps a smaller effective top
+offset (shell's `pt-40` alone, no extra page padding, ~160px) instead of matching the
+other pages pixel-for-pixel, and its wheel-sizing CSS constants were adjusted to reflect
+the reduced budget. If this page's UI is reworked in the future, revisit whether it can
+absorb the full standard offset.

--- a/wongsakorn127-byjaimesjames/docs/status-board.md
+++ b/wongsakorn127-byjaimesjames/docs/status-board.md
@@ -8,10 +8,11 @@ Update this file in the same commit whenever a ticket's status changes on the bo
 _(none)_
 
 ## In Progress
-- WSK127-002 [UxUi/FE] Inform privacy policy before register
+- WSK127-006 [UxUi/FE] Shared shell for title/nav/profile
 
 ## Done
 - WSK127-001 [Full] Nosy Game first spin
+- WSK127-002 [UxUi/FE] Inform privacy policy before register
 - WSK127-003 [Bug] Google profile photo fails to load
 - WSK127-004 [Bug] Production release pipeline fails to deploy Firestore rules
 - WSK127-005 [Bug] Dependabot angular PRs conflict with each other

--- a/wongsakorn127-byjaimesjames/docs/tickets/WSK127-006-shared-shell.md
+++ b/wongsakorn127-byjaimesjames/docs/tickets/WSK127-006-shared-shell.md
@@ -1,0 +1,38 @@
+# WSK127-006 [UxUi/FE] Shared shell for title/nav/profile
+
+- Kanban: https://github.com/JaimesJames/Wongsakorn127/issues/39
+- Status: In Progress
+- Branch: feature/WSK127-006-shared-shell
+
+## Acceptance Criteria
+- [x] New `ShellComponent` (`core/layout/shell/`) renders `CreditBadgeComponent` at one
+      consistent position/spacing shared by every page.
+- [x] `ShellComponent` accepts `contentAlign: 'top' | 'center'` (default `'top'`).
+- [x] `ShellComponent` accepts `isLight`, passed through to `CreditBadgeComponent`.
+- [x] `home`, `nosygame`, `kingleegame` migrated to `<app-shell>`; top spacing identical
+      (verified: 200px badge offset on all three).
+- [x] `auth` migrated to `<app-shell contentAlign="center">`; centered layout preserved
+      (verified: form vertically centered).
+- [x] Unit tests for `ShellComponent` cover both alignment variants and `isLight`.
+- [x] Layout contract doc added (`docs/shell-layout-contract.md`).
+
+## Design notes / decisions
+- `spinitgame` could not match the 200px offset used by the other four pages without
+  clipping its fixed-height wheel layout — see the "Known exception" section in
+  `docs/shell-layout-contract.md`. Kept at a smaller offset (~160px) with its wheel-sizing
+  CSS constants adjusted accordingly. Decision confirmed with the user in chat.
+- `home`'s dead `isLoading`-driven padding branch (always `false`, never toggled) was
+  removed as part of the migration since the shell now owns that spacing.
+- `nosygame` used `overflow-y-scroll` (always-reserved scrollbar gutter) while
+  `kingleegame` used `overflow-hidden` (no gutter), which shifted the now-identical
+  vertical positions ~7.5px apart horizontally once vertical spacing matched exactly.
+  Fixed by switching `nosygame` to `overflow-y-auto` with `scrollbar-gutter: stable
+  both-edges`, so both pages reserve symmetric gutter regardless of whether a scrollbar
+  is actually shown.
+
+## Test plan
+- `npm run test:ci` — 62/62 passing.
+- `npm run build` — passing.
+- Manual verification in browser for all 5 pages: title position, no clipping/overflow
+  (checked at 1280x720 and 375x812), auth centering preserved, spin-it wheel fits both
+  desktop and mobile viewports without functional regressions.

--- a/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.html
@@ -1,7 +1,7 @@
 <main
-  class="w-screen max-w-[720px] m-auto h-screen flex flex-col justify-center text-center p-10 gap-2 transition-all duration-300 overflow-y-scroll"
+  class="w-screen max-w-[720px] m-auto h-screen flex flex-col text-center p-10 gap-2 transition-all duration-300 overflow-y-scroll"
   >
-  <app-credit-badge [isLight]="true"></app-credit-badge>
+  <app-shell [isLight]="true" contentAlign="center">
   <app-initial-loading [isLoading]="isLoading"></app-initial-loading>
   @if (!isLoading) {
     <div class="flex flex-col gap-5">
@@ -190,4 +190,5 @@
                       </footer>
                     </div>
                   }
+                  </app-shell>
                 </main>

--- a/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/auth/auth.component.ts
@@ -3,7 +3,7 @@ import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { AbstractControl, FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators, ValidationErrors } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { InitialLoadingComponent } from '../../share/components/loading/initialLoading.component';
-import { CreditBadgeComponent } from '../../share/components/badges/creditBadge/creditBadge.component';
+import { ShellComponent } from '../layout/shell/shell.component';
 import { AuthService } from '../../adapters/angular/services/auth/auth.service';
 import { getFirebaseUserMessage } from '../../../infrastructure/firebase/firebaseError';
 
@@ -11,7 +11,7 @@ import { getFirebaseUserMessage } from '../../../infrastructure/firebase/firebas
 @Component({
   selector: 'app-auth',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterLink, InitialLoadingComponent, CreditBadgeComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterLink, InitialLoadingComponent, ShellComponent],
   templateUrl: './auth.component.html',
   styleUrls: ['./auth.component.css'],
 })

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.html
@@ -1,0 +1,10 @@
+<div
+  class="flex w-full flex-1 flex-col items-center gap-5"
+  [ngClass]="{
+    'justify-start pt-40': contentAlign === 'top',
+    'justify-center': contentAlign === 'center'
+  }"
+>
+  <app-credit-badge class="z-1" [isLight]="isLight" />
+  <ng-content></ng-content>
+</div>

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShellComponent } from './shell.component';
+
+describe('ShellComponent', () => {
+  let component: ShellComponent;
+  let fixture: ComponentFixture<ShellComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ShellComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShellComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('defaults to top-aligned content', () => {
+    const container = fixture.nativeElement.querySelector('div');
+    expect(container.classList).toContain('justify-start');
+    expect(container.classList).not.toContain('justify-center');
+  });
+
+  it('centers content when contentAlign is "center"', () => {
+    component.contentAlign = 'center';
+    fixture.detectChanges();
+    const container = fixture.nativeElement.querySelector('div');
+    expect(container.classList).toContain('justify-center');
+    expect(container.classList).not.toContain('justify-start');
+  });
+
+  it('passes isLight through to the credit badge', () => {
+    component.isLight = true;
+    fixture.detectChanges();
+    const badge = fixture.nativeElement.querySelector('app-credit-badge h2');
+    expect(badge.parentElement.classList).toContain('text-text-bglight');
+  });
+});

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CreditBadgeComponent } from '../../../share/components/badges/creditBadge/creditBadge.component';
+
+@Component({
+  selector: 'app-shell',
+  standalone: true,
+  imports: [CommonModule, CreditBadgeComponent],
+  templateUrl: './shell.component.html',
+})
+export class ShellComponent {
+  @Input() isLight = false;
+  @Input() contentAlign: 'top' | 'center' = 'top';
+}

--- a/wongsakorn127-byjaimesjames/src/app/feature/initial/page/home/home.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/initial/page/home/home.component.html
@@ -1,11 +1,7 @@
 <main
-  class="w-screen h-screen bg-light-bg flex flex-col p-10 text-center overflow-hidden transition-all duration-300 justify-start"
-  [ngClass]="{
-    'pt-[40vh] gap-20': isLoading,
-    'pt-40 gap-5': !isLoading ,
-  }"
+  class="w-screen h-screen bg-light-bg flex flex-col p-10 text-center overflow-hidden transition-all duration-300"
 >
-  <app-credit-badge class="z-1" [isLight]="true"></app-credit-badge>
+  <app-shell [isLight]="true"></app-shell>
   <img
     class="absolute top-0 left-0 h-full z-0"
     src="svg/home-left.svg"

--- a/wongsakorn127-byjaimesjames/src/app/feature/initial/page/home/home.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/initial/page/home/home.component.ts
@@ -1,14 +1,13 @@
 import { Component } from '@angular/core';
-import { CreditBadgeComponent } from '../../../../share/components/badges/creditBadge/creditBadge.component';
+import { ShellComponent } from '../../../../core/layout/shell/shell.component';
 import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-home',
-  imports: [CreditBadgeComponent, CommonModule],
+  imports: [ShellComponent, CommonModule],
   templateUrl: './home.component.html',
   styleUrl: './home.component.css',
   standalone: true
 })
 export class HomeComponent {
-  isLoading:boolean = false
 }

--- a/wongsakorn127-byjaimesjames/src/app/feature/kingleeGame/page/kingleegame/kingleegame.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/kingleeGame/page/kingleegame/kingleegame.component.html
@@ -1,8 +1,7 @@
 <main
-  class="w-screen h-screen bg-kinglee-game flex flex-col p-10 text-center overflow-hidden transition-all duration-300 justify-start"
-  [ngClass]="{ 'pt-[40vh] gap-20': isLoading, 'pt-40 gap-5': !isLoading&&!isEditMode, 'pt-25 gap-3': !isLoading&&isEditMode }"
+  class="w-screen h-screen bg-kinglee-game flex flex-col p-10 text-center overflow-hidden transition-all duration-300"
   >
-  <app-credit-badge [isLight]="true" />
+  <app-shell [isLight]="true">
   <app-initial-loading [isLoading]="isLoading"></app-initial-loading>
   <app-confirm-dialog></app-confirm-dialog>
 
@@ -11,5 +10,6 @@
       <app-deck [deck]="deck"></app-deck>
     </div>
   }
+  </app-shell>
 </main>
 

--- a/wongsakorn127-byjaimesjames/src/app/feature/kingleeGame/page/kingleegame/kingleegame.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/kingleeGame/page/kingleegame/kingleegame.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { CreditBadgeComponent } from '../../../../share/components/badges/creditBadge/creditBadge.component';
+import { ShellComponent } from '../../../../core/layout/shell/shell.component';
 import { InitialLoadingComponent } from '../../../../share/components/loading/initialLoading.component';
 import { ConfirmDialogComponent } from '../../../../share/components/dialog/confirmDialog.component';
 import { DeckComponent } from '../../components/deck.component';
@@ -10,7 +10,7 @@ import { initialCardValue } from '../../services/kingleegame.data';
 
 @Component({
   selector: 'app-kingleegame',
-  imports: [CommonModule, CreditBadgeComponent, InitialLoadingComponent, ConfirmDialogComponent, DeckComponent],
+  imports: [CommonModule, ShellComponent, InitialLoadingComponent, ConfirmDialogComponent, DeckComponent],
   templateUrl: './kingleegame.component.html',
   styleUrl: './kingleegame.component.css',
   standalone: true

--- a/wongsakorn127-byjaimesjames/src/app/feature/nosyGame/page/nosygame/nosygame.component.css
+++ b/wongsakorn127-byjaimesjames/src/app/feature/nosyGame/page/nosygame/nosygame.component.css
@@ -1,0 +1,3 @@
+main {
+  scrollbar-gutter: stable both-edges;
+}

--- a/wongsakorn127-byjaimesjames/src/app/feature/nosyGame/page/nosygame/nosygame.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/nosyGame/page/nosygame/nosygame.component.html
@@ -1,8 +1,7 @@
 <main
-  class="w-screen h-screen bg-nosy-game flex flex-col p-10 text-center overflow-y-scroll transition-all duration-300 justify-start"
-  [ngClass]="{ 'pt-[40vh] gap-20': isLoading, 'pt-40 gap-5': !isLoading&&!isEditMode, 'pt-29 gap-3': !isLoading&&isEditMode }"
+  class="w-screen h-screen bg-nosy-game flex flex-col p-10 text-center overflow-y-auto transition-all duration-300"
   >
-  <app-credit-badge [isLight]="false" />
+  <app-shell [isLight]="false">
   <app-initial-loading [isLoading]="isLoading"></app-initial-loading>
   <app-confirm-dialog></app-confirm-dialog>
 
@@ -93,6 +92,7 @@
       }
     </div>
   }
+  </app-shell>
   <img class="absolute h-full top-0 left-0" src="svg/nosy-left.svg" alt="nosy-left">
   <img class="absolute h-full top-0 right-0" src="svg/nosy-right.svg" alt="nosy-right">
 </main>

--- a/wongsakorn127-byjaimesjames/src/app/feature/nosyGame/page/nosygame/nosygame.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/nosyGame/page/nosygame/nosygame.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Inject, PLATFORM_ID, ViewChild } from '@angular/core';
-import { CreditBadgeComponent } from '../../../../share/components/badges/creditBadge/creditBadge.component';
+import { ShellComponent } from '../../../../core/layout/shell/shell.component';
 import { selectionBarComponent } from '../../../../share/components/input/selectionBar.component';
 import { QuestionsText } from '../../../../../core/nosyGame/entities/QuestionsText';
 import { RequestSet } from '../../../../../core/nosyGame/entities/RequestSet';
@@ -15,7 +15,7 @@ import { getFirebaseUserMessage } from '../../../../../infrastructure/firebase/f
 
 @Component({
   selector: 'app-nosygame',
-  imports: [CreditBadgeComponent, selectionBarComponent, EditListComponent, CommonModule, RouterModule, ConfirmDialogComponent, InitialLoadingComponent],
+  imports: [ShellComponent, selectionBarComponent, EditListComponent, CommonModule, RouterModule, ConfirmDialogComponent, InitialLoadingComponent],
   templateUrl: './nosygame.component.html',
   styleUrl: './nosygame.component.css',
   standalone: true

--- a/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.css
+++ b/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.css
@@ -36,14 +36,14 @@
 
 .wheel-area {
   position: relative;
-  width: max(260px, min(82vw, calc(100dvh - var(--bottom-nav-peek) - 340px), 620px));
+  width: max(260px, min(82vw, calc(100dvh - var(--bottom-nav-peek) - 456px), 620px));
   aspect-ratio: 1;
   flex: 0 0 auto;
   transition: width 260ms ease, transform 260ms ease;
 }
 
 .settings-open .wheel-area {
-  width: max(260px, min(50vw, calc(100dvh - var(--bottom-nav-peek) - 320px), 560px));
+  width: max(260px, min(50vw, calc(100dvh - var(--bottom-nav-peek) - 436px), 560px));
 }
 
 .wheel {

--- a/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.html
@@ -1,5 +1,5 @@
-<main class="spinit-page min-h-screen bg-spinit-game px-5 pb-28 pt-28 text-center text-white overflow-x-hidden">
-  <app-credit-badge [isLight]="false" />
+<main class="spinit-page min-h-screen bg-spinit-game px-5 pb-16 text-center text-white overflow-x-hidden">
+  <app-shell [isLight]="false">
 
   <section
     class="game-layout mx-auto mt-8 flex w-full flex-col items-center justify-center gap-5"
@@ -350,4 +350,5 @@
       >Nice</button>
     </div>
   }
+  </app-shell>
 </main>

--- a/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.ts
@@ -4,11 +4,11 @@ import { FormsModule } from '@angular/forms';
 import { CdkOverlayOrigin, ConnectedPosition, OverlayModule } from '@angular/cdk/overlay';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { ColorPickerDirective } from 'ngx-color-picker';
-import { CreditBadgeComponent } from '../../../../share/components/badges/creditBadge/creditBadge.component';
+import { ShellComponent } from '../../../../core/layout/shell/shell.component';
 
 @Component({
   selector: 'app-spinitgame',
-  imports: [CommonModule, FormsModule, OverlayModule, DragDropModule, ColorPickerDirective, CreditBadgeComponent],
+  imports: [CommonModule, FormsModule, OverlayModule, DragDropModule, ColorPickerDirective, ShellComponent],
   templateUrl: './spinitgame.component.html',
   styleUrl: './spinitgame.component.css',
   standalone: true


### PR DESCRIPTION
## Summary
- New `ShellComponent` (`core/layout/shell/`) owns the title spot (`CreditBadgeComponent`) at one consistent position/spacing, with a `contentAlign: 'top' | 'center'` input and `isLight` passthrough.
- Migrated `home`, `nosygame`, `kingleegame` to `<app-shell>` — verified identical title position (200px) and horizontal centering across all three (fixed an unrelated pre-existing scrollbar-gutter mismatch between nosygame and kingleegame along the way).
- Migrated `auth` to `<app-shell contentAlign="center">`, preserving its centered form layout.
- `spinitgame` migrated too, but keeps a smaller top offset (~160px) since its fixed-height, budget-critical wheel layout clipped when matching the other pages' spacing exactly — documented as a known exception in `docs/shell-layout-contract.md`, confirmed with the user.
- Added `docs/shell-layout-contract.md` (the layout contract) and `docs/tickets/WSK127-006-shared-shell.md` (ticket spec).

Closes #39

## Test plan
- [x] `npm run test:ci` — 62/62 passing (new `ShellComponent` tests for both alignment variants and `isLight`)
- [x] `npm run build` — passing
- [x] Verified live in browser at 1280x720 and 375x812: title position identical on home/nosygame/kingleegame (pixel-measured, not just visual), auth stays centered, spin-it wheel fits without clipping on both viewports, horizontal centering fixed between nosygame/kingleegame