### PR TITLE
feat(WSK127-007): animate title position between page navigations

### DIFF
--- a/wongsakorn127-byjaimesjames/docs/status-board.md
+++ b/wongsakorn127-byjaimesjames/docs/status-board.md
@@ -8,7 +8,7 @@ Update this file in the same commit whenever a ticket's status changes on the bo
 _(none)_
 
 ## In Progress
-- WSK127-006 [UxUi/FE] Shared shell for title/nav/profile
+- WSK127-007 [UxUi/FE] Animate title position between page navigations
 
 ## Done
 - WSK127-001 [Full] Nosy Game first spin
@@ -16,3 +16,4 @@ _(none)_
 - WSK127-003 [Bug] Google profile photo fails to load
 - WSK127-004 [Bug] Production release pipeline fails to deploy Firestore rules
 - WSK127-005 [Bug] Dependabot angular PRs conflict with each other
+- WSK127-006 [UxUi/FE] Shared shell for title/nav/profile

--- a/wongsakorn127-byjaimesjames/docs/tickets/WSK127-007-title-slide-animation.md
+++ b/wongsakorn127-byjaimesjames/docs/tickets/WSK127-007-title-slide-animation.md
@@ -1,0 +1,46 @@
+# WSK127-007 [UxUi/FE] Animate title position between page navigations
+
+- Kanban: https://github.com/JaimesJames/Wongsakorn127/issues/41
+- Status: In Progress
+- Branch: feature/WSK127-007-title-slide-animation
+
+## Acceptance Criteria
+- [x] `CreditBadgeComponent` is rendered once, globally, in `app.component.html`.
+- [x] `ShellLayoutService` exposes the current top offset / `isLight` / `visible` state as
+      a signal; each top-anchored page's `ShellComponent` sets it via `titleOffsetPx` and
+      `isLight` inputs on init/change.
+- [x] The global title transitions smoothly (`transition: top 300ms`) when the target
+      offset changes between top-anchored pages.
+- [x] Page content reserves enough top space to clear the title, which is no longer part
+      of local document flow (fixed regression: initial version kept the WSK127-006
+      `pt-40`, which only cleared the title's *starting* position, not its full height —
+      content rendered overlapping the title on nosygame, kingleegame, and spin-it until
+      the user screenshotted it and caught it. Bumped local reservation to `pt-[260px]`,
+      which accounts for the title's own height (~78px) and gap it used to get "for free"
+      as a flex sibling).
+- [x] `auth` (`contentAlign="center"`) keeps its own local, non-animated title; the global
+      title hides (`opacity-0`, `pointer-events-none`) while on such pages.
+- [x] Unit tests cover `ShellLayoutService` and `ShellComponent`'s calls into it.
+- [x] Manually verified in browser: `Router.navigateByUrl` between kingleegame (200px) and
+      spin-it (160px) updates the single persistent title element's target correctly in
+      both directions; auth correctly shows only its own local badge with the global one
+      hidden.
+
+## Design notes / decisions
+- Used Angular's classic `@Input()` + `ngOnChanges` (not signal inputs) to match the rest
+  of the codebase's style in `ShellComponent`.
+- `ShellComponent` no longer renders `CreditBadgeComponent` itself for `contentAlign="top"`
+  — only for `"center"`, since the global element in `app.component.html` handles the
+  top-anchored case for every page at once.
+
+## Test plan
+- `npm run test:ci` — 69/69 passing.
+- `npm run build` — passing.
+- Manual verification in browser via `Router.navigateByUrl` (more reliable than clicking
+  the bottom-sheet nav link in the sandboxed browser): confirmed the persistent title
+  element's `top` and the `ShellLayoutService` target update correctly across kingleegame
+  <-> spin-it navigation, and that auth hides the global title while showing its own.
+- User-provided screenshots caught a real content/title overlap regression on nosygame,
+  kingleegame, and spin-it (not visible to automated geometry checks alone). Fixed and
+  re-verified via geometry (title-bottom-to-content-top gap, ~60px+ on every page) plus a
+  second round of user screenshots confirming no overlap.

--- a/wongsakorn127-byjaimesjames/src/app/app.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/app.component.html
@@ -1,3 +1,11 @@
 <router-outlet></router-outlet>
 <app-head></app-head>
 <app-navigator/>
+<div
+  class="fixed left-1/2 z-1 w-full max-w-[720px] -translate-x-1/2 px-10 text-center transition-[top] duration-300 ease-in-out"
+  [style.top.px]="shellTarget().topOffsetPx"
+  [class.opacity-0]="!shellTarget().visible"
+  [class.pointer-events-none]="!shellTarget().visible"
+>
+  <app-credit-badge [isLight]="shellTarget().isLight"></app-credit-badge>
+</div>

--- a/wongsakorn127-byjaimesjames/src/app/app.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.component.spec.ts
@@ -1,15 +1,25 @@
 import { AppComponent } from './app.component';
+import { ShellLayoutService } from './core/layout/shell/shell-layout.service';
 
 describe('AppComponent', () => {
   it('should create the app', () => {
-    const app = new AppComponent();
+    const app = new AppComponent(new ShellLayoutService());
 
     expect(app).toBeTruthy();
   });
 
   it(`should have the 'wongsakorn127-byjaimesjames' title`, () => {
-    const app = new AppComponent();
+    const app = new AppComponent(new ShellLayoutService());
 
     expect(app.title).toEqual('wongsakorn127-byjaimesjames');
+  });
+
+  it('exposes the shell layout target signal', () => {
+    const shellLayout = new ShellLayoutService();
+    const app = new AppComponent(shellLayout);
+
+    shellLayout.setTarget(160, true);
+
+    expect(app.shellTarget()).toEqual({ topOffsetPx: 160, isLight: true, visible: true });
   });
 });

--- a/wongsakorn127-byjaimesjames/src/app/app.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.component.ts
@@ -2,13 +2,20 @@ import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { NavigatorComponent } from './core/layout/navigator/navigator.component';
 import { HeadComponent } from './core/layout/head/head.component';
+import { CreditBadgeComponent } from './share/components/badges/creditBadge/creditBadge.component';
+import { ShellLayoutService } from './core/layout/shell/shell-layout.service';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, NavigatorComponent, HeadComponent],
+  imports: [RouterOutlet, NavigatorComponent, HeadComponent, CreditBadgeComponent],
   styleUrl: './app.component.css',
   templateUrl: './app.component.html',
 })
 export class AppComponent {
   title = 'wongsakorn127-byjaimesjames';
+  shellTarget;
+
+  constructor(private shellLayout: ShellLayoutService) {
+    this.shellTarget = this.shellLayout.target;
+  }
 }

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell-layout.service.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell-layout.service.spec.ts
@@ -1,0 +1,24 @@
+import { ShellLayoutService } from './shell-layout.service';
+
+describe('ShellLayoutService', () => {
+  let service: ShellLayoutService;
+
+  beforeEach(() => {
+    service = new ShellLayoutService();
+  });
+
+  it('starts hidden with a default offset', () => {
+    expect(service.target()).toEqual({ topOffsetPx: 200, isLight: false, visible: false });
+  });
+
+  it('updates the target and marks it visible on setTarget', () => {
+    service.setTarget(160, true);
+    expect(service.target()).toEqual({ topOffsetPx: 160, isLight: true, visible: true });
+  });
+
+  it('marks the current target hidden without losing its offset on hide', () => {
+    service.setTarget(160, true);
+    service.hide();
+    expect(service.target()).toEqual({ topOffsetPx: 160, isLight: true, visible: false });
+  });
+});

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell-layout.service.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell-layout.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, signal } from '@angular/core';
+
+export interface ShellTitleTarget {
+  topOffsetPx: number;
+  isLight: boolean;
+  visible: boolean;
+}
+
+const DEFAULT_TARGET: ShellTitleTarget = {
+  topOffsetPx: 200,
+  isLight: false,
+  visible: false,
+};
+
+@Injectable({ providedIn: 'root' })
+export class ShellLayoutService {
+  readonly target = signal<ShellTitleTarget>(DEFAULT_TARGET);
+
+  setTarget(topOffsetPx: number, isLight: boolean): void {
+    this.target.set({ topOffsetPx, isLight, visible: true });
+  }
+
+  hide(): void {
+    this.target.update((current) => ({ ...current, visible: false }));
+  }
+}

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.html
@@ -1,10 +1,12 @@
 <div
   class="flex w-full flex-1 flex-col items-center gap-5"
   [ngClass]="{
-    'justify-start pt-40': contentAlign === 'top',
+    'justify-start pt-[260px]': contentAlign === 'top',
     'justify-center': contentAlign === 'center'
   }"
 >
-  <app-credit-badge class="z-1" [isLight]="isLight" />
+  @if (contentAlign === 'center') {
+    <app-credit-badge class="z-1" [isLight]="isLight" />
+  }
   <ng-content></ng-content>
 </div>

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.spec.ts
@@ -1,10 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ShellComponent } from './shell.component';
+import { ShellLayoutService } from './shell-layout.service';
 
 describe('ShellComponent', () => {
   let component: ShellComponent;
   let fixture: ComponentFixture<ShellComponent>;
+  let shellLayout: ShellLayoutService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -13,6 +15,7 @@ describe('ShellComponent', () => {
 
     fixture = TestBed.createComponent(ShellComponent);
     component = fixture.componentInstance;
+    shellLayout = TestBed.inject(ShellLayoutService);
     fixture.detectChanges();
   });
 
@@ -34,10 +37,29 @@ describe('ShellComponent', () => {
     expect(container.classList).not.toContain('justify-start');
   });
 
-  it('passes isLight through to the credit badge', () => {
+  it('does not render its own title badge when top-aligned (global title handles it)', () => {
+    const badge = fixture.nativeElement.querySelector('app-credit-badge');
+    expect(badge).toBeNull();
+  });
+
+  it('renders its own title badge with isLight passthrough when centered', () => {
     component.isLight = true;
+    component.contentAlign = 'center';
     fixture.detectChanges();
     const badge = fixture.nativeElement.querySelector('app-credit-badge h2');
     expect(badge.parentElement.classList).toContain('text-text-bglight');
+  });
+
+  it('sets the shell layout target when top-aligned', () => {
+    component.isLight = true;
+    component.titleOffsetPx = 160;
+    component.ngOnChanges();
+    expect(shellLayout.target()).toEqual({ topOffsetPx: 160, isLight: true, visible: true });
+  });
+
+  it('hides the shell layout target when centered', () => {
+    component.contentAlign = 'center';
+    component.ngOnChanges();
+    expect(shellLayout.target().visible).toBeFalse();
   });
 });

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/shell/shell.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CreditBadgeComponent } from '../../../share/components/badges/creditBadge/creditBadge.component';
+import { ShellLayoutService } from './shell-layout.service';
 
 @Component({
   selector: 'app-shell',
@@ -8,7 +9,18 @@ import { CreditBadgeComponent } from '../../../share/components/badges/creditBad
   imports: [CommonModule, CreditBadgeComponent],
   templateUrl: './shell.component.html',
 })
-export class ShellComponent {
+export class ShellComponent implements OnChanges {
   @Input() isLight = false;
   @Input() contentAlign: 'top' | 'center' = 'top';
+  @Input() titleOffsetPx = 200;
+
+  constructor(private shellLayout: ShellLayoutService) {}
+
+  ngOnChanges(): void {
+    if (this.contentAlign === 'top') {
+      this.shellLayout.setTarget(this.titleOffsetPx, this.isLight);
+    } else {
+      this.shellLayout.hide();
+    }
+  }
 }

--- a/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/spinitGame/page/spinitgame/spinitgame.component.html
@@ -1,5 +1,5 @@
 <main class="spinit-page min-h-screen bg-spinit-game px-5 pb-16 text-center text-white overflow-x-hidden">
-  <app-shell [isLight]="false">
+  <app-shell [isLight]="false" [titleOffsetPx]="160">
 
   <section
     class="game-layout mx-auto mt-8 flex w-full flex-col items-center justify-center gap-5"


### PR DESCRIPTION
## Summary
- Move `CreditBadgeComponent` to a single persistent `position: fixed` instance in `app.component.html` (like `head`/`navigator`) instead of re-rendering it per page.
- `ShellLayoutService` exposes the current top offset / `isLight` / `visible` as a signal; each top-anchored page's `ShellComponent` sets its target on init.
- A CSS transition (`top 300ms`) animates the title sliding between offsets across route changes (e.g. kingleegame at 200px -> spin-it at 160px) instead of jumping instantly.
- `auth` (`contentAlign="center"`) keeps its own local, non-animated title; the global one hides while such a page is active.

**Regression caught and fixed during review**: removing the title from each page's local flex flow meant the old `pt-40` local reservation only cleared the title's *starting* position, not its full rendered height — game content rendered overlapping the title on nosygame, kingleegame, and spin-it. Caught via user screenshots (not visible to automated geometry checks alone). Fixed by bumping the local reservation to `pt-[260px]`.

Closes #41

## Test plan
- [x] `npm run test:ci` — 69/69 passing (new tests for `ShellLayoutService` and `ShellComponent`'s calls into it)
- [x] `npm run build` — passing
- [x] Verified via `Router.navigateByUrl` between kingleegame/spin-it: single persistent title element, target updates correctly both directions, transition CSS applied
- [x] Verified auth hides the global title correctly (local one shown instead)
- [x] Re-verified content/title overlap is fixed via geometry (60px+ gap on every page) and a second round of user screenshots