### PR TITLE
feat(WSK127-008): add XO game (base, no skills)

### DIFF
--- a/wongsakorn127-byjaimesjames/docs/status-board.md
+++ b/wongsakorn127-byjaimesjames/docs/status-board.md
@@ -5,10 +5,10 @@ Kanban: https://github.com/users/JaimesJames/projects/1
 Update this file in the same commit whenever a ticket's status changes on the board.
 
 ## Todo
-_(none)_
+- WSK127-009 [Full] XO game special mechanics (skills/cards)
 
 ## In Progress
-- WSK127-007 [UxUi/FE] Animate title position between page navigations
+- WSK127-008 [Full] XO game (base, no skills)
 
 ## Done
 - WSK127-001 [Full] Nosy Game first spin
@@ -17,3 +17,4 @@ _(none)_
 - WSK127-004 [Bug] Production release pipeline fails to deploy Firestore rules
 - WSK127-005 [Bug] Dependabot angular PRs conflict with each other
 - WSK127-006 [UxUi/FE] Shared shell for title/nav/profile
+- WSK127-007 [UxUi/FE] Animate title position between page navigations

--- a/wongsakorn127-byjaimesjames/docs/tickets/WSK127-008-xo-game-base.md
+++ b/wongsakorn127-byjaimesjames/docs/tickets/WSK127-008-xo-game-base.md
@@ -1,0 +1,40 @@
+# WSK127-008 [Full] XO game (base, no skills)
+
+- Kanban: https://github.com/JaimesJames/Wongsakorn127/issues/43
+- Status: In Progress
+- Branch: feature/WSK127-008-xo-game-base
+
+## Acceptance Criteria
+- [x] New route `/xo-game` (`feature/xoGame/`), using `ShellComponent`.
+- [x] Player can choose board size before starting a match: 3x3, 4x4, or 5x5.
+- [x] Two players alternate turns (X and O) on the same device — no login required.
+- [x] Win condition: `min(boardSize, 5)` marks in a row, any of the 4 directions.
+- [x] Draw detected when the board fills with no winner.
+- [x] UI shows current turn, announces winner/draw, "play again" and "change size".
+- [x] Added to bottom navigation (text badge "XO" — no custom artwork yet, see notes).
+- [x] Unit tests cover win detection across all 3 sizes and all directions, plus draw.
+- [x] Manually verified in browser: 3x3 win, 4x4 win (confirms 3-in-a-row does NOT win on
+      a 4x4 board), size selector, no title/content overlap.
+
+## Design notes / decisions
+- Win-length rule (`min(boardSize, 5)`, Gomoku-style) and size range (3-5) confirmed with
+  the user in chat.
+- Win detection logic lives in a pure, framework-free function
+  (`xogame-win-checker.ts`) for easy, fast unit testing — same pattern worth reusing for
+  future game logic.
+- No custom badge artwork exists yet; used a plain "XO" text badge on `bg-xo-game`
+  (new theme color, `#FF6B4A`) instead of blocking on an image asset. Swap for real
+  artwork later — this is explicitly a UX/UI design space, so the visual polish pass is
+  expected as its own follow-up, not scope creep on this ticket.
+- Named `xo-game` for now; may be renamed to `duckylucky` once the full feature set
+  (including skills, see WSK127-009) is built out, per a prior class project the user
+  built the original concept for (https://github.com/SutheeraP/duckylucky — Next.js/
+  Firebase, referenced for design ideas only, not ported directly).
+
+## Test plan
+- `npm run test:ci` — 88/88 passing.
+- `npm run build` — passing.
+- Manual verification in browser: played a 3x3 match to an X win, a 4x4 match to an X win
+  (confirming the win-length scales correctly), verified the size-selection and
+  in-progress screens don't overlap the global title (gap ~22px, consistent with other
+  pages).

--- a/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
@@ -30,6 +30,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Client
   },
   {
+    path: 'xo-game',
+    renderMode: RenderMode.Client
+  },
+  {
     path: '**',
     renderMode: RenderMode.Client
   }

--- a/wongsakorn127-byjaimesjames/src/app/app.routes.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.ts
@@ -34,5 +34,10 @@ export const routes: Routes = [
   {
     path: 'legal',
     loadComponent: () => import('./feature/legal/page/legal.component').then(m => m.LegalComponent),
+  },
+  {
+    path: 'xo-game',
+    loadComponent: () => import('./feature/xoGame/page/xogame/xogame.component').then(m => m.XogameComponent),
+    canActivate: [ParamsGuard]
   }
 ];

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/navigator/navigator.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/navigator/navigator.component.html
@@ -28,34 +28,34 @@
         <img src="spinit-badge.png" alt="spinit-badge">
       </button>
     </a>
-    <a>  
-      <button class="bg-light-lazy w-[148px] h-[96px] rounded-2xl opacity-30 hover:cursor-pointer">
-        
+    <a [routerLink]="['/xo-game']" [queryParams]="{mode:'game'}">
+      <button class="bg-xo-game w-[148px] h-[96px] rounded-2xl font-semibold text-2xl text-white hover:cursor-pointer">
+        XO
       </button>
     </a>
-    <a>  
+    <a>
       <button class="bg-light-lazy w-[148px] h-[96px] rounded-2xl opacity-30 hover:cursor-pointer">
-        
+
       </button>
     </a>
-    <a>  
+    <a>
       <button class="bg-light-lazy w-[148px] h-[96px] rounded-2xl opacity-30 hover:cursor-pointer">
-        
+
       </button>
     </a>
-    <a>  
+    <a>
       <button class="bg-light-lazy w-[148px] h-[96px] rounded-2xl opacity-30 hover:cursor-pointer">
-        
+
       </button>
     </a>
-    <a>  
+    <a>
       <button class="bg-light-lazy w-[148px] h-[96px] rounded-2xl opacity-30 hover:cursor-pointer">
-        
+
       </button>
     </a>
-    <a>  
+    <a>
       <button class="bg-light-lazy w-[148px] h-[96px] rounded-2xl opacity-30 hover:cursor-pointer">
-        
+
       </button>
     </a>
     <a>  

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.html
@@ -1,0 +1,68 @@
+<main class="w-screen h-screen bg-xo-game flex flex-col p-10 text-center overflow-y-auto transition-all duration-300">
+  <app-shell [isLight]="false">
+    @if (!gameStarted) {
+      <div class="flex flex-col items-center gap-5">
+        <h2 class="text-3xl font-semibold text-white">Choose board size</h2>
+        <div class="flex gap-3">
+          @for (size of boardSizeOptions; track size) {
+            <button
+              type="button"
+              (click)="selectBoardSize(size)"
+              [ngClass]="{
+                'bg-white text-xo-game': boardSize === size,
+                'bg-transparent text-white border-2 border-white': boardSize !== size
+              }"
+              class="w-16 h-16 rounded-2xl text-xl font-semibold"
+            >{{ size }}x{{ size }}</button>
+          }
+        </div>
+        <button
+          type="button"
+          (click)="startGame()"
+          class="mt-3 rounded-full bg-white px-8 py-3 text-xl font-semibold text-xo-game"
+        >Start</button>
+      </div>
+    } @else {
+      <div class="flex flex-col items-center gap-5">
+        @if (!winner && !isDraw) {
+          <h2 class="text-2xl font-semibold text-white">Turn: {{ currentPlayer }}</h2>
+        }
+
+        <div
+          class="grid gap-2"
+          [style.grid-template-columns]="'repeat(' + boardSize + ', minmax(0, 1fr))'"
+        >
+          @for (cell of board; track $index) {
+            <button
+              type="button"
+              (click)="playCell($index)"
+              [disabled]="!!cell || !!winner || isDraw"
+              class="flex aspect-square w-16 items-center justify-center rounded-xl bg-white text-3xl font-bold text-xo-game disabled:cursor-not-allowed"
+            >{{ cell }}</button>
+          }
+        </div>
+
+        @if (winner) {
+          <p class="text-2xl font-semibold text-white">{{ winner }} wins!</p>
+        } @else if (isDraw) {
+          <p class="text-2xl font-semibold text-white">Draw!</p>
+        }
+
+        @if (winner || isDraw) {
+          <div class="flex gap-3">
+            <button
+              type="button"
+              (click)="playAgain()"
+              class="rounded-full bg-white px-6 py-2 text-lg font-semibold text-xo-game"
+            >Play again</button>
+            <button
+              type="button"
+              (click)="changeBoardSize()"
+              class="rounded-full border-2 border-white px-6 py-2 text-lg font-semibold text-white"
+            >Change size</button>
+          </div>
+        }
+      </div>
+    }
+  </app-shell>
+</main>

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.spec.ts
@@ -1,0 +1,116 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { XogameComponent } from './xogame.component';
+import { Cell } from '../../services/xogame-win-checker';
+
+describe('XogameComponent', () => {
+  let component: XogameComponent;
+  let fixture: ComponentFixture<XogameComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [XogameComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(XogameComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('starts on the board-size selection screen', () => {
+    expect(component.gameStarted).toBeFalse();
+  });
+
+  it('starts a game with an empty board of the chosen size', () => {
+    component.selectBoardSize(4);
+    component.startGame();
+
+    expect(component.gameStarted).toBeTrue();
+    expect(component.board.length).toBe(16);
+    expect(component.board.every((cell) => cell === null)).toBeTrue();
+    expect(component.currentPlayer).toBe('X');
+  });
+
+  it('alternates turns after each move', () => {
+    component.selectBoardSize(3);
+    component.startGame();
+
+    component.playCell(0);
+    expect(component.board[0]).toBe('X');
+    expect(component.currentPlayer).toBe('O');
+
+    component.playCell(1);
+    expect(component.board[1]).toBe('O');
+    expect(component.currentPlayer).toBe('X');
+  });
+
+  it('ignores a move on an already-occupied cell', () => {
+    component.selectBoardSize(3);
+    component.startGame();
+
+    component.playCell(0);
+    component.playCell(0);
+
+    expect(component.board[0]).toBe('X');
+    expect(component.currentPlayer).toBe('O');
+  });
+
+  it('declares a winner and stops accepting moves', () => {
+    component.selectBoardSize(3);
+    component.startGame();
+
+    // X: 0,1,2 (top row) with O playing elsewhere in between
+    component.playCell(0); // X
+    component.playCell(3); // O
+    component.playCell(1); // X
+    component.playCell(4); // O
+    component.playCell(2); // X wins
+
+    expect(component.winner).toBe('X');
+
+    component.playCell(5);
+    expect(component.board[5]).toBeNull();
+  });
+
+  it('declares a draw when the board fills with no winner', () => {
+    component.selectBoardSize(3);
+    component.startGame();
+    // Final board, filled with no 3-in-a-row for either mark:
+    // X O X
+    // X O O
+    // O X X
+    const expectedBoard: Cell[] = ['X', 'O', 'X', 'X', 'O', 'O', 'O', 'X', 'X'];
+    const moves = [0, 1, 2, 4, 3, 5, 7, 6, 8];
+    moves.forEach((idx) => component.playCell(idx));
+
+    expect(component.board).toEqual(expectedBoard);
+    expect(component.isDraw).toBeTrue();
+    expect(component.winner).toBeNull();
+  });
+
+  it('playAgain resets the board but keeps the chosen size', () => {
+    component.selectBoardSize(4);
+    component.startGame();
+    component.playCell(0);
+
+    component.playAgain();
+
+    expect(component.board.length).toBe(16);
+    expect(component.board.every((cell) => cell === null)).toBeTrue();
+    expect(component.winner).toBeNull();
+    expect(component.isDraw).toBeFalse();
+  });
+
+  it('changeBoardSize returns to the size-selection screen', () => {
+    component.selectBoardSize(3);
+    component.startGame();
+
+    component.changeBoardSize();
+
+    expect(component.gameStarted).toBeFalse();
+  });
+});

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.ts
@@ -1,0 +1,69 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ShellComponent } from '../../../../core/layout/shell/shell.component';
+import { Cell, Mark, checkWinner, getWinLength, isBoardFull } from '../../services/xogame-win-checker';
+
+type BoardSize = 3 | 4 | 5;
+
+@Component({
+  selector: 'app-xogame',
+  standalone: true,
+  imports: [CommonModule, ShellComponent],
+  templateUrl: './xogame.component.html',
+  styleUrl: './xogame.component.css',
+})
+export class XogameComponent {
+  readonly boardSizeOptions: BoardSize[] = [3, 4, 5];
+
+  boardSize: BoardSize = 3;
+  gameStarted = false;
+  board: Cell[] = [];
+  currentPlayer: Mark = 'X';
+  winner: Mark | null = null;
+  isDraw = false;
+
+  get winLength(): number {
+    return getWinLength(this.boardSize);
+  }
+
+  selectBoardSize(size: BoardSize): void {
+    this.boardSize = size;
+  }
+
+  startGame(): void {
+    this.board = new Array(this.boardSize * this.boardSize).fill(null);
+    this.currentPlayer = 'X';
+    this.winner = null;
+    this.isDraw = false;
+    this.gameStarted = true;
+  }
+
+  playCell(index: number): void {
+    if (this.winner || this.isDraw || this.board[index]) {
+      return;
+    }
+
+    this.board[index] = this.currentPlayer;
+
+    const winner = checkWinner(this.board, this.boardSize);
+    if (winner) {
+      this.winner = winner;
+      return;
+    }
+
+    if (isBoardFull(this.board)) {
+      this.isDraw = true;
+      return;
+    }
+
+    this.currentPlayer = this.currentPlayer === 'X' ? 'O' : 'X';
+  }
+
+  playAgain(): void {
+    this.startGame();
+  }
+
+  changeBoardSize(): void {
+    this.gameStarted = false;
+  }
+}

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/services/xogame-win-checker.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/services/xogame-win-checker.spec.ts
@@ -1,0 +1,89 @@
+import { checkWinner, getWinLength, isBoardFull, Cell } from './xogame-win-checker';
+
+function emptyBoard(size: number): Cell[] {
+  return new Array(size * size).fill(null);
+}
+
+describe('getWinLength', () => {
+  it('matches the board size for sizes up to 5', () => {
+    expect(getWinLength(3)).toBe(3);
+    expect(getWinLength(4)).toBe(4);
+    expect(getWinLength(5)).toBe(5);
+  });
+});
+
+describe('checkWinner', () => {
+  it('returns null when nobody has won', () => {
+    const board = emptyBoard(3);
+    board[0] = 'X';
+    board[1] = 'O';
+    expect(checkWinner(board, 3)).toBeNull();
+  });
+
+  it('detects a horizontal win on a 3x3 board', () => {
+    const board = emptyBoard(3);
+    board[3] = 'X';
+    board[4] = 'X';
+    board[5] = 'X';
+    expect(checkWinner(board, 3)).toBe('X');
+  });
+
+  it('detects a vertical win on a 3x3 board', () => {
+    const board = emptyBoard(3);
+    board[0] = 'O';
+    board[3] = 'O';
+    board[6] = 'O';
+    expect(checkWinner(board, 3)).toBe('O');
+  });
+
+  it('detects a diagonal win (top-left to bottom-right) on a 3x3 board', () => {
+    const board = emptyBoard(3);
+    board[0] = 'X';
+    board[4] = 'X';
+    board[8] = 'X';
+    expect(checkWinner(board, 3)).toBe('X');
+  });
+
+  it('detects an anti-diagonal win (top-right to bottom-left) on a 3x3 board', () => {
+    const board = emptyBoard(3);
+    board[2] = 'O';
+    board[4] = 'O';
+    board[6] = 'O';
+    expect(checkWinner(board, 3)).toBe('O');
+  });
+
+  it('requires 4 in a row on a 4x4 board; 3 in a row is not a win', () => {
+    const board = emptyBoard(4);
+    board[0] = 'X';
+    board[1] = 'X';
+    board[2] = 'X';
+    expect(checkWinner(board, 4)).toBeNull();
+
+    board[3] = 'X';
+    expect(checkWinner(board, 4)).toBe('X');
+  });
+
+  it('requires 5 in a row on a 5x5 board', () => {
+    const board = emptyBoard(5);
+    for (let i = 0; i < 4; i++) {
+      board[i] = 'O';
+    }
+    expect(checkWinner(board, 5)).toBeNull();
+
+    board[4] = 'O';
+    expect(checkWinner(board, 5)).toBe('O');
+  });
+});
+
+describe('isBoardFull', () => {
+  it('returns false when at least one cell is empty', () => {
+    const board = emptyBoard(3);
+    board[0] = 'X';
+    expect(isBoardFull(board)).toBeFalse();
+  });
+
+  it('returns true when every cell is filled', () => {
+    const board: Cell[] = new Array(9).fill('X');
+    expect(isBoardFull(board)).toBeTrue();
+  });
+});

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/services/xogame-win-checker.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/services/xogame-win-checker.ts
@@ -1,0 +1,43 @@
+export type Mark = 'X' | 'O';
+export type Cell = Mark | null;
+
+export function getWinLength(boardSize: number): number {
+  return Math.min(boardSize, 5);
+}
+
+export function checkWinner(board: Cell[], boardSize: number): Mark | null {
+  const winLength = getWinLength(boardSize);
+  const directions = [
+    { dx: 1, dy: 0 },
+    { dx: 0, dy: 1 },
+    { dx: 1, dy: 1 },
+    { dx: 1, dy: -1 },
+  ];
+
+  for (let y = 0; y < boardSize; y++) {
+    for (let x = 0; x < boardSize; x++) {
+      const mark = board[y * boardSize + x];
+      if (!mark) continue;
+
+      for (const { dx, dy } of directions) {
+        let count = 1;
+        for (let step = 1; step < winLength; step++) {
+          const nx = x + dx * step;
+          const ny = y + dy * step;
+          if (nx < 0 || nx >= boardSize || ny < 0 || ny >= boardSize) break;
+          if (board[ny * boardSize + nx] !== mark) break;
+          count++;
+        }
+        if (count >= winLength) {
+          return mark;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function isBoardFull(board: Cell[]): boolean {
+  return board.every((cell) => cell !== null);
+}

--- a/wongsakorn127-byjaimesjames/src/styles.css
+++ b/wongsakorn127-byjaimesjames/src/styles.css
@@ -16,6 +16,7 @@
     --color-kinglee-game: #86FF73;
     --color-dude-or-there: #B83CF2;
     --color-spinit-game: #7137C8;
+    --color-xo-game: #FF6B4A;
 }
 
 /* Spin It owns the popup shell; the package only renders the color plane and hue control. */


### PR DESCRIPTION
## Summary
- New local 2-player (pass-and-play) tic-tac-toe at `/xo-game`, following the existing game page pattern (`ShellComponent`, background theme, credit badge).
- Board size is configurable: 3x3, 4x4, or 5x5, picked before starting a match.
- Win condition: `min(boardSize, 5)` marks in a row (Gomoku-style), checked horizontally, vertically, and both diagonals.
- Draw detected when the board fills with no winner.
- Win/draw detection is a pure, framework-free function (`xogame-win-checker.ts`) for fast, thorough unit testing.
- Added to the bottom nav with a plain "XO" text badge for now — no custom artwork yet.

No skills/cards in this ticket — that's tracked separately in #44 (WSK127-009), inspired by a prior class project (https://github.com/SutheeraP/duckylucky) but not decided/designed yet.

Closes #43

## Test plan
- [x] `npm run test:ci` — 88/88 passing (10 new tests for win detection across all board sizes/directions/draw, 8 new component tests)
- [x] `npm run build` — passing
- [x] Verified live in browser: played a 3x3 match to an X win and a 4x4 match to an X win (confirms 3-in-a-row does *not* win on a 4x4 board), size selector and "change size"/"play again" flows, no title/content overlap