### PR TITLE
feat(WSK127-009): add optional Block/Remove skills to XO game

### DIFF
--- a/wongsakorn127-byjaimesjames/docs/status-board.md
+++ b/wongsakorn127-byjaimesjames/docs/status-board.md
@@ -5,10 +5,10 @@ Kanban: https://github.com/users/JaimesJames/projects/1
 Update this file in the same commit whenever a ticket's status changes on the board.
 
 ## Todo
-- WSK127-009 [Full] XO game special mechanics (skills/cards)
+_(none)_
 
 ## In Progress
-- WSK127-008 [Full] XO game (base, no skills)
+- WSK127-009 [Full] XO game special mechanics (skills/cards)
 
 ## Done
 - WSK127-001 [Full] Nosy Game first spin
@@ -18,3 +18,4 @@ Update this file in the same commit whenever a ticket's status changes on the bo
 - WSK127-005 [Bug] Dependabot angular PRs conflict with each other
 - WSK127-006 [UxUi/FE] Shared shell for title/nav/profile
 - WSK127-007 [UxUi/FE] Animate title position between page navigations
+- WSK127-008 [Full] XO game (base, no skills)

--- a/wongsakorn127-byjaimesjames/docs/tickets/WSK127-009-xo-game-skills.md
+++ b/wongsakorn127-byjaimesjames/docs/tickets/WSK127-009-xo-game-skills.md
@@ -1,0 +1,47 @@
+# WSK127-009 [Full] XO game special mechanics (skills/cards)
+
+- Kanban: https://github.com/JaimesJames/Wongsakorn127/issues/44
+- Status: In Progress
+- Branch: feature/WSK127-009-xo-game-skills
+
+## Acceptance Criteria
+- [x] "Enable skills" checkbox on the board-size selection screen (off by default).
+- [x] Skills-disabled mode behaves exactly like WSK127-008.
+- [x] Skills-enabled mode: each player gets one Block charge and one Remove charge.
+  - [x] Block: target an empty, unblocked cell; blocked for exactly 2 turns (opponent's
+        next turn, then the blocker's next turn), then free again.
+  - [x] Remove: target a cell holding the opponent's mark; clears it.
+- [x] Using a skill consumes the turn (no mark placed that turn).
+- [x] Skill selection UI with per-skill charge count, disabled once spent, and a cancel
+      action.
+- [x] Blocked cells show a lock marker and reject placement.
+- [x] Skills unavailable once the game has a winner or is a draw.
+- [x] Unit tests for all of the above (skills-disabled parity, block timing/expiry,
+      block rejects placement, remove valid/invalid targets, charge exhaustion, cancel,
+      skills disabled after game end).
+- [x] Manually verified in browser (see Test plan).
+
+## Design notes / decisions
+- Simplified deliberately from the original Ducky Lucky reference (action-point economy
+  + card hand + random board-effect slots) down to two always-available, single-use
+  skills on top of plain alternating turns — confirmed with the user in chat.
+- Block duration counts turns via a per-cell `blockedTurnsRemaining` counter, decremented
+  once per turn for every block *except* the one just placed that same turn (so a fresh
+  block isn't immediately ticked down in the turn it's created). This gives the intended
+  "opponent's turn + placer's next turn" duration exactly.
+- Board special-effect slots and additional skills remain out of scope — future tickets.
+
+## Test plan
+- `npm run test:ci` — 96/96 passing.
+- `npm run build` — passing.
+- Manual verification in browser using the real component instance (`ng.getComponent`)
+  to read authoritative state after each interaction (page-text snapshots were
+  occasionally stale in the sandboxed browser, so state was double-checked this way):
+  - Block: placed on cell 4, confirmed locked marker + disabled button, confirmed
+    rejection while blocked for both the opponent's and the placer's next turn, confirmed
+    it unblocks and becomes placeable exactly after those 2 turns.
+  - Remove: confirmed rejecting a target that's the acting player's own mark (charge and
+    turn unchanged), then confirmed removing the opponent's actual mark works (board
+    cleared, charge decremented, turn passed).
+  - Skills-disabled mode: confirmed no skill UI renders and play proceeds identically to
+    WSK127-008.

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.html
@@ -16,6 +16,10 @@
             >{{ size }}x{{ size }}</button>
           }
         </div>
+        <label class="flex items-center gap-2 text-lg font-semibold text-white">
+          <input type="checkbox" [checked]="skillsEnabled" (change)="toggleSkills()" />
+          Enable skills
+        </label>
         <button
           type="button"
           (click)="startGame()"
@@ -28,6 +32,40 @@
           <h2 class="text-2xl font-semibold text-white">Turn: {{ currentPlayer }}</h2>
         }
 
+        @if (skillsEnabled && !winner && !isDraw) {
+          <div class="flex flex-col items-center gap-2">
+            <div class="flex gap-3">
+              <button
+                type="button"
+                (click)="selectSkill('block')"
+                [disabled]="skillCharges[currentPlayer].block <= 0"
+                [ngClass]="{
+                  'bg-white text-xo-game': selectedSkill === 'block',
+                  'bg-transparent text-white border-2 border-white': selectedSkill !== 'block'
+                }"
+                class="rounded-full px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+              >Block ({{ skillCharges[currentPlayer].block }})</button>
+              <button
+                type="button"
+                (click)="selectSkill('remove')"
+                [disabled]="skillCharges[currentPlayer].remove <= 0"
+                [ngClass]="{
+                  'bg-white text-xo-game': selectedSkill === 'remove',
+                  'bg-transparent text-white border-2 border-white': selectedSkill !== 'remove'
+                }"
+                class="rounded-full px-4 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
+              >Remove ({{ skillCharges[currentPlayer].remove }})</button>
+            </div>
+            @if (selectedSkill) {
+              <button
+                type="button"
+                (click)="cancelSkill()"
+                class="text-sm text-white underline"
+              >Cancel {{ selectedSkill }}</button>
+            }
+          </div>
+        }
+
         <div
           class="grid gap-2"
           [style.grid-template-columns]="'repeat(' + boardSize + ', minmax(0, 1fr))'"
@@ -36,9 +74,10 @@
             <button
               type="button"
               (click)="playCell($index)"
-              [disabled]="!!cell || !!winner || isDraw"
+              [disabled]="isCellDisabled($index)"
+              [ngClass]="{ 'bg-xo-game/40': isBlocked($index) }"
               class="flex aspect-square w-16 items-center justify-center rounded-xl bg-white text-3xl font-bold text-xo-game disabled:cursor-not-allowed"
-            >{{ cell }}</button>
+            >{{ isBlocked($index) ? '🔒' : cell }}</button>
           }
         </div>
 

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.spec.ts
@@ -113,4 +113,123 @@ describe('XogameComponent', () => {
 
     expect(component.gameStarted).toBeFalse();
   });
+
+  describe('skills disabled (default)', () => {
+    it('grants no skill charges and selecting a skill has no effect', () => {
+      component.selectBoardSize(3);
+      component.startGame();
+
+      expect(component.skillCharges['X'].block).toBe(0);
+      expect(component.skillCharges['X'].remove).toBe(0);
+
+      component.selectSkill('block');
+      expect(component.selectedSkill).toBeNull();
+
+      // Behaves exactly like the base game: playCell places a mark normally.
+      component.playCell(0);
+      expect(component.board[0]).toBe('X');
+    });
+  });
+
+  describe('skills enabled', () => {
+    beforeEach(() => {
+      component.toggleSkills();
+      component.selectBoardSize(3);
+      component.startGame();
+    });
+
+    it('grants each player one charge of each skill', () => {
+      expect(component.skillCharges['X']).toEqual({ block: 1, remove: 1 });
+      expect(component.skillCharges['O']).toEqual({ block: 1, remove: 1 });
+    });
+
+    it('blocks a cell for exactly 2 turns (opponent + placer), then frees it', () => {
+      // X blocks cell 4.
+      component.selectSkill('block');
+      component.playCell(4);
+      expect(component.isBlocked(4)).toBeTrue();
+      expect(component.skillCharges['X'].block).toBe(0);
+      expect(component.currentPlayer).toBe('O');
+
+      // O cannot place on the blocked cell.
+      component.playCell(4);
+      expect(component.board[4]).toBeNull();
+      expect(component.currentPlayer).toBe('O');
+
+      // O plays elsewhere (turn 1 of the block's duration).
+      component.playCell(0);
+      expect(component.isBlocked(4)).toBeTrue();
+      expect(component.currentPlayer).toBe('X');
+
+      // X cannot place on the still-blocked cell either.
+      component.playCell(4);
+      expect(component.board[4]).toBeNull();
+
+      // X plays elsewhere (turn 2 of the block's duration) - now it clears.
+      component.playCell(1);
+      expect(component.isBlocked(4)).toBeFalse();
+      expect(component.currentPlayer).toBe('O');
+
+      // Now placeable again.
+      component.playCell(4);
+      expect(component.board[4]).toBe('O');
+    });
+
+    it('removes the target opponent mark and consumes the turn', () => {
+      component.playCell(0); // X
+      component.playCell(1); // O
+
+      component.selectSkill('remove');
+      component.playCell(1); // X removes O's mark at 1
+
+      expect(component.board[1]).toBeNull();
+      expect(component.skillCharges['X'].remove).toBe(0);
+      expect(component.currentPlayer).toBe('O');
+      expect(component.selectedSkill).toBeNull();
+    });
+
+    it('rejects removing an empty cell or the player\'s own mark', () => {
+      component.playCell(0); // X
+      component.playCell(1); // O - it's X's turn again
+
+      component.selectSkill('remove');
+      component.playCell(2); // empty - invalid target
+      expect(component.skillCharges['X'].remove).toBe(1);
+      expect(component.currentPlayer).toBe('X');
+
+      component.playCell(0); // X's own mark - invalid target for X's remove
+      expect(component.board[0]).toBe('X');
+      expect(component.skillCharges['X'].remove).toBe(1);
+    });
+
+    it('cannot use a skill a second time once its charge is spent', () => {
+      component.selectSkill('block');
+      component.playCell(4); // X spends its block charge
+      component.playCell(0); // O
+      // X's turn again
+      component.selectSkill('block');
+      expect(component.selectedSkill).toBeNull();
+    });
+
+    it('cancelSkill clears the selection without consuming a turn or charge', () => {
+      component.selectSkill('block');
+      component.cancelSkill();
+
+      expect(component.selectedSkill).toBeNull();
+      expect(component.skillCharges['X'].block).toBe(1);
+      expect(component.currentPlayer).toBe('X');
+    });
+
+    it('does not allow selecting a skill once the game has ended', () => {
+      component.playCell(0); // X
+      component.playCell(3); // O
+      component.playCell(1); // X
+      component.playCell(4); // O
+      component.playCell(2); // X wins
+
+      expect(component.winner).toBe('X');
+      component.selectSkill('remove');
+      expect(component.selectedSkill).toBeNull();
+    });
+  });
 });

--- a/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/xoGame/page/xogame/xogame.component.ts
@@ -4,6 +4,14 @@ import { ShellComponent } from '../../../../core/layout/shell/shell.component';
 import { Cell, Mark, checkWinner, getWinLength, isBoardFull } from '../../services/xogame-win-checker';
 
 type BoardSize = 3 | 4 | 5;
+export type Skill = 'block' | 'remove';
+
+interface SkillCharges {
+  block: number;
+  remove: number;
+}
+
+const BLOCK_DURATION_TURNS = 2;
 
 @Component({
   selector: 'app-xogame',
@@ -16,34 +24,125 @@ export class XogameComponent {
   readonly boardSizeOptions: BoardSize[] = [3, 4, 5];
 
   boardSize: BoardSize = 3;
+  skillsEnabled = false;
   gameStarted = false;
   board: Cell[] = [];
   currentPlayer: Mark = 'X';
   winner: Mark | null = null;
   isDraw = false;
 
+  blockedTurnsRemaining: (number | null)[] = [];
+  selectedSkill: Skill | null = null;
+  skillCharges: Record<Mark, SkillCharges> = {
+    X: { block: 0, remove: 0 },
+    O: { block: 0, remove: 0 },
+  };
+
   get winLength(): number {
     return getWinLength(this.boardSize);
+  }
+
+  get opponent(): Mark {
+    return this.currentPlayer === 'X' ? 'O' : 'X';
   }
 
   selectBoardSize(size: BoardSize): void {
     this.boardSize = size;
   }
 
+  toggleSkills(): void {
+    this.skillsEnabled = !this.skillsEnabled;
+  }
+
   startGame(): void {
-    this.board = new Array(this.boardSize * this.boardSize).fill(null);
+    const cellCount = this.boardSize * this.boardSize;
+    this.board = new Array(cellCount).fill(null);
+    this.blockedTurnsRemaining = new Array(cellCount).fill(null);
     this.currentPlayer = 'X';
     this.winner = null;
     this.isDraw = false;
+    this.selectedSkill = null;
+    this.skillCharges = {
+      X: { block: this.skillsEnabled ? 1 : 0, remove: this.skillsEnabled ? 1 : 0 },
+      O: { block: this.skillsEnabled ? 1 : 0, remove: this.skillsEnabled ? 1 : 0 },
+    };
     this.gameStarted = true;
   }
 
+  isBlocked(index: number): boolean {
+    return this.blockedTurnsRemaining[index] != null;
+  }
+
+  selectSkill(skill: Skill): void {
+    if (this.winner || this.isDraw) {
+      return;
+    }
+    if (this.skillCharges[this.currentPlayer][skill] <= 0) {
+      return;
+    }
+    this.selectedSkill = skill;
+  }
+
+  cancelSkill(): void {
+    this.selectedSkill = null;
+  }
+
+  isCellDisabled(index: number): boolean {
+    if (this.winner || this.isDraw) {
+      return true;
+    }
+    if (this.selectedSkill === 'block') {
+      return !!this.board[index] || this.isBlocked(index);
+    }
+    if (this.selectedSkill === 'remove') {
+      return this.board[index] !== this.opponent;
+    }
+    return !!this.board[index] || this.isBlocked(index);
+  }
+
   playCell(index: number): void {
-    if (this.winner || this.isDraw || this.board[index]) {
+    if (this.winner || this.isDraw) {
+      return;
+    }
+
+    if (this.selectedSkill) {
+      this.applySkill(index);
+      return;
+    }
+
+    if (this.board[index] || this.isBlocked(index)) {
       return;
     }
 
     this.board[index] = this.currentPlayer;
+    this.endTurn(index);
+  }
+
+  private applySkill(index: number): void {
+    const skill = this.selectedSkill;
+    if (!skill) {
+      return;
+    }
+
+    if (skill === 'block') {
+      if (this.board[index] || this.isBlocked(index)) {
+        return;
+      }
+      this.blockedTurnsRemaining[index] = BLOCK_DURATION_TURNS;
+    } else {
+      if (this.board[index] !== this.opponent) {
+        return;
+      }
+      this.board[index] = null;
+    }
+
+    this.skillCharges[this.currentPlayer][skill]--;
+    this.selectedSkill = null;
+    this.endTurn(index);
+  }
+
+  private endTurn(actedIndex: number): void {
+    this.tickBlocks(actedIndex);
 
     const winner = checkWinner(this.board, this.boardSize);
     if (winner) {
@@ -56,7 +155,17 @@ export class XogameComponent {
       return;
     }
 
-    this.currentPlayer = this.currentPlayer === 'X' ? 'O' : 'X';
+    this.currentPlayer = this.opponent;
+  }
+
+  private tickBlocks(skipIndex: number): void {
+    for (let i = 0; i < this.blockedTurnsRemaining.length; i++) {
+      if (i === skipIndex || this.blockedTurnsRemaining[i] == null) {
+        continue;
+      }
+      const remaining = (this.blockedTurnsRemaining[i] as number) - 1;
+      this.blockedTurnsRemaining[i] = remaining > 0 ? remaining : null;
+    }
   }
 
   playAgain(): void {


### PR DESCRIPTION
## Summary
- Add an "Enable skills" checkbox to the XO game's board-size selection screen (off by default).
- When enabled, each player gets one **Block** charge (lock an empty, unblocked cell for exactly 2 turns — the opponent's next turn, then the placer's own next turn) and one **Remove** charge (clear a cell holding the opponent's mark).
- Using a skill consumes the turn instead of placing a mark; skill buttons show remaining charges and disable once spent; a cancel action clears the selection without cost.
- Skills-disabled mode is unchanged from WSK127-008.

Simplified deliberately from the original Ducky Lucky reference (https://github.com/SutheeraP/duckylucky — action-point economy, card hand, random board-effect slots) down to two always-available, single-use skills on top of plain alternating turns.

Closes #44

## Test plan
- [x] `npm run test:ci` — 96/96 passing (new tests: skills-disabled parity, block timing/expiry, block rejects placement, remove valid/invalid targets, charge exhaustion, cancel, skills disabled after game end)
- [x] `npm run build` — passing
- [x] Verified live in browser (reading component state via `ng.getComponent` for authoritative checks): Block locks the target cell, both players are rejected while it's active, it frees up after exactly 2 turns; Remove rejects removing your own mark, correctly clears the opponent's mark and consumes the charge/turn; skills-disabled mode shows no skill UI and behaves identically to WSK127-008