### PR TITLE
feat(WSK127-010): add Bomb game (wasabi roulette, base)

### DIFF
--- a/wongsakorn127-byjaimesjames/docs/status-board.md
+++ b/wongsakorn127-byjaimesjames/docs/status-board.md
@@ -8,7 +8,7 @@ Update this file in the same commit whenever a ticket's status changes on the bo
 _(none)_
 
 ## In Progress
-- WSK127-009 [Full] XO game special mechanics (skills/cards)
+- WSK127-010 [Full] Bomb game (wasabi roulette, base)
 
 ## Done
 - WSK127-001 [Full] Nosy Game first spin
@@ -19,3 +19,4 @@ _(none)_
 - WSK127-006 [UxUi/FE] Shared shell for title/nav/profile
 - WSK127-007 [UxUi/FE] Animate title position between page navigations
 - WSK127-008 [Full] XO game (base, no skills)
+- WSK127-009 [Full] XO game special mechanics (skills/cards)

--- a/wongsakorn127-byjaimesjames/docs/tickets/WSK127-010-bomb-game-base.md
+++ b/wongsakorn127-byjaimesjames/docs/tickets/WSK127-010-bomb-game-base.md
@@ -1,0 +1,42 @@
+# WSK127-010 [Full] Bomb game (wasabi roulette, base)
+
+- Kanban: https://github.com/JaimesJames/Wongsakorn127/issues/47
+- Status: In Progress
+- Branch: feature/WSK127-010-bomb-game-base
+
+## Acceptance Criteria
+- [x] New route `/bomb-game` (`feature/bombGame/`), using `ShellComponent`.
+- [x] Setup screen: choose bombs-per-player (1 or 2) before starting.
+- [x] Hand-off interstitial before each player's placement turn.
+- [x] Placement screen: 10-cell pile shown as neutral; active player selects exactly N
+      bombs before confirming; previously-placed bombs from the other player are
+      indistinguishable from safe cells.
+- [x] After both place, eating phase begins, visible to both; turns alternate (Player 1
+      starts).
+- [x] Safe pick reveals and passes the turn.
+- [x] Bomb pick ends the game immediately, sets the loser, reveals remaining bombs.
+- [x] "Play again" resets to the setup screen.
+- [x] Unit tests: placement validation, overlapping bomb selections, safe pick,
+      bomb pick + reveal, guaranteed resolution.
+- [x] Manually verified in browser (see Test plan).
+
+## Design notes / decisions
+- Overlapping bomb selections between the two players are allowed and handled silently
+  (the cell is simply a bomb either way) — confirmed as an acceptable simplification
+  with the user rather than adding target-picking constraints.
+- "Play again" always returns to the setup screen rather than replaying with the same
+  settings, for simplicity (both were acceptable per the AC).
+- No pure/standalone logic module this time (unlike the XO win-checker) — game state is
+  simple enough that direct component-level tests were sufficient and match the style of
+  the earlier, simpler games (kingleeGame).
+
+## Test plan
+- `npm run test:ci` — 111/111 passing.
+- `npm run build` — passing.
+- Manual verification in browser using `ng.getComponent` for authoritative state checks:
+  - Full playthrough with 1 bomb/player: Player 1 places at index 3, hand-off to Player 2
+    who sees an all-neutral pile (confirmed Player 1's bomb position is not visible),
+    places at index 7, confirmed both bombs land in `bombs` correctly.
+  - Eating phase: safe pick at index 0 reveals it and passes the turn; bomb pick at index
+    3 ends the game, sets the correct loser, and reveals the remaining bomb at index 7.
+  - No title/content overlap (gap ~22px, consistent with other pages).

--- a/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.server.ts
@@ -34,6 +34,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Client
   },
   {
+    path: 'bomb-game',
+    renderMode: RenderMode.Client
+  },
+  {
     path: '**',
     renderMode: RenderMode.Client
   }

--- a/wongsakorn127-byjaimesjames/src/app/app.routes.ts
+++ b/wongsakorn127-byjaimesjames/src/app/app.routes.ts
@@ -39,5 +39,10 @@ export const routes: Routes = [
     path: 'xo-game',
     loadComponent: () => import('./feature/xoGame/page/xogame/xogame.component').then(m => m.XogameComponent),
     canActivate: [ParamsGuard]
+  },
+  {
+    path: 'bomb-game',
+    loadComponent: () => import('./feature/bombGame/page/bombgame/bombgame.component').then(m => m.BombgameComponent),
+    canActivate: [ParamsGuard]
   }
 ];

--- a/wongsakorn127-byjaimesjames/src/app/core/layout/navigator/navigator.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/core/layout/navigator/navigator.component.html
@@ -33,9 +33,9 @@
         XO
       </button>
     </a>
-    <a>
-      <button class="bg-light-lazy w-[148px] h-[96px] rounded-2xl opacity-30 hover:cursor-pointer">
-
+    <a [routerLink]="['/bomb-game']" [queryParams]="{mode:'game'}">
+      <button class="bg-bomb-game w-[148px] h-[96px] rounded-2xl font-semibold text-2xl text-white hover:cursor-pointer">
+        💣
       </button>
     </a>
     <a>

--- a/wongsakorn127-byjaimesjames/src/app/feature/bombGame/page/bombgame/bombgame.component.html
+++ b/wongsakorn127-byjaimesjames/src/app/feature/bombGame/page/bombgame/bombgame.component.html
@@ -1,0 +1,86 @@
+<main class="w-screen h-screen bg-bomb-game flex flex-col p-10 text-center overflow-y-auto transition-all duration-300">
+  <app-shell [isLight]="false">
+    @if (phase === 'setup') {
+      <div class="flex flex-col items-center gap-5">
+        <h2 class="text-3xl font-semibold text-white">Bombs per player</h2>
+        <div class="flex gap-3">
+          @for (count of bombOptions; track count) {
+            <button
+              type="button"
+              (click)="selectBombsPerPlayer(count)"
+              [ngClass]="{
+                'bg-white text-bomb-game': bombsPerPlayer === count,
+                'bg-transparent text-white border-2 border-white': bombsPerPlayer !== count
+              }"
+              class="w-16 h-16 rounded-2xl text-xl font-semibold"
+            >{{ count }}</button>
+          }
+        </div>
+        <button
+          type="button"
+          (click)="startSetup()"
+          class="mt-3 rounded-full bg-white px-8 py-3 text-xl font-semibold text-bomb-game"
+        >Start</button>
+      </div>
+    } @else if (phase === 'handoff') {
+      <div class="flex flex-col items-center gap-5">
+        <h2 class="text-2xl font-semibold text-white">Pass the device to Player {{ placingPlayer }}</h2>
+        <p class="text-white/80">Only Player {{ placingPlayer }} should be looking at the screen.</p>
+        <button
+          type="button"
+          (click)="confirmHandoff()"
+          class="rounded-full bg-white px-8 py-3 text-xl font-semibold text-bomb-game"
+        >Ready</button>
+      </div>
+    } @else if (phase === 'placement') {
+      <div class="flex flex-col items-center gap-5">
+        <h2 class="text-2xl font-semibold text-white">
+          Player {{ placingPlayer }}: place {{ bombsPerPlayer }} bomb{{ bombsPerPlayer > 1 ? 's' : '' }}
+        </h2>
+        <p class="text-white/80">Selected {{ placementSelections.length }} / {{ bombsPerPlayer }}</p>
+        <div class="grid grid-cols-5 gap-2">
+          @for (item of bombs; track $index) {
+            <button
+              type="button"
+              (click)="togglePlacementCell($index)"
+              [ngClass]="{ 'bg-bomb-game text-white': isSelectedForPlacement($index) }"
+              class="flex aspect-square w-14 items-center justify-center rounded-xl bg-white text-2xl text-bomb-game"
+            >{{ isSelectedForPlacement($index) ? '💣' : '🍣' }}</button>
+          }
+        </div>
+        <button
+          type="button"
+          (click)="confirmPlacement()"
+          [disabled]="!canConfirmPlacement()"
+          class="rounded-full bg-white px-8 py-3 text-xl font-semibold text-bomb-game disabled:cursor-not-allowed disabled:opacity-40"
+        >Confirm</button>
+      </div>
+    } @else {
+      <div class="flex flex-col items-center gap-5">
+        @if (phase === 'eating') {
+          <h2 class="text-2xl font-semibold text-white">Player {{ currentEater }}'s turn to pick</h2>
+        }
+
+        <div class="grid grid-cols-5 gap-2">
+          @for (item of bombs; track $index) {
+            <button
+              type="button"
+              (click)="pickCell($index)"
+              [disabled]="phase !== 'eating' || revealed[$index] !== null"
+              class="flex aspect-square w-14 items-center justify-center rounded-xl bg-white text-2xl text-bomb-game disabled:cursor-not-allowed"
+            >{{ revealed[$index] === 'bomb' ? '💥' : revealed[$index] === 'safe' ? '✅' : '🍣' }}</button>
+          }
+        </div>
+
+        @if (phase === 'ended') {
+          <p class="text-2xl font-semibold text-white">Player {{ loser }} picked a bomb! Player {{ loser === 1 ? 2 : 1 }} wins!</p>
+          <button
+            type="button"
+            (click)="playAgain()"
+            class="rounded-full bg-white px-6 py-2 text-lg font-semibold text-bomb-game"
+          >Play again</button>
+        }
+      </div>
+    }
+  </app-shell>
+</main>

--- a/wongsakorn127-byjaimesjames/src/app/feature/bombGame/page/bombgame/bombgame.component.spec.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/bombGame/page/bombgame/bombgame.component.spec.ts
@@ -1,0 +1,184 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BombgameComponent } from './bombgame.component';
+
+describe('BombgameComponent', () => {
+  let component: BombgameComponent;
+  let fixture: ComponentFixture<BombgameComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BombgameComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BombgameComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('starts on the setup screen', () => {
+    expect(component.phase).toBe('setup');
+  });
+
+  it('startSetup moves to the handoff screen for player 1', () => {
+    component.startSetup();
+    expect(component.phase).toBe('handoff');
+    expect(component.placingPlayer).toBe(1);
+    expect(component.bombs.length).toBe(10);
+    expect(component.bombs.every((b) => !b)).toBeTrue();
+  });
+
+  describe('placement', () => {
+    beforeEach(() => {
+      component.startSetup();
+      component.confirmHandoff();
+    });
+
+    it('toggles a selection on and off', () => {
+      component.togglePlacementCell(2);
+      expect(component.isSelectedForPlacement(2)).toBeTrue();
+
+      component.togglePlacementCell(2);
+      expect(component.isSelectedForPlacement(2)).toBeFalse();
+    });
+
+    it('cannot select more than bombsPerPlayer cells', () => {
+      component.selectBombsPerPlayer(1);
+      component.togglePlacementCell(0);
+      component.togglePlacementCell(1); // should be ignored, already have 1
+
+      expect(component.placementSelections).toEqual([0]);
+    });
+
+    it('cannot confirm until exactly bombsPerPlayer cells are selected', () => {
+      component.selectBombsPerPlayer(2);
+      expect(component.canConfirmPlacement()).toBeFalse();
+
+      component.togglePlacementCell(0);
+      expect(component.canConfirmPlacement()).toBeFalse();
+
+      component.togglePlacementCell(1);
+      expect(component.canConfirmPlacement()).toBeTrue();
+    });
+
+    it('after player 1 confirms, moves to handoff for player 2 without revealing bombs', () => {
+      component.togglePlacementCell(3);
+      component.confirmPlacement();
+
+      expect(component.bombs[3]).toBeTrue();
+      expect(component.phase).toBe('handoff');
+      expect(component.placingPlayer).toBe(2);
+      // Player 2's placement screen must not show player 1's bomb.
+      expect(component.placementSelections).toEqual([]);
+    });
+
+    it('after player 2 confirms, moves to the eating phase', () => {
+      component.togglePlacementCell(3);
+      component.confirmPlacement(); // player 1 done
+
+      component.confirmHandoff(); // player 2's placement screen
+      component.togglePlacementCell(7);
+      component.confirmPlacement(); // player 2 done
+
+      expect(component.phase).toBe('eating');
+      expect(component.currentEater).toBe(1);
+      expect(component.bombs[3]).toBeTrue();
+      expect(component.bombs[7]).toBeTrue();
+    });
+
+    it('handles overlapping bomb selections between players without error', () => {
+      component.togglePlacementCell(5);
+      component.confirmPlacement(); // player 1 bombs cell 5
+
+      component.confirmHandoff();
+      component.togglePlacementCell(5); // player 2 also picks cell 5
+      component.confirmPlacement();
+
+      expect(component.phase).toBe('eating');
+      expect(component.bombs.filter(Boolean).length).toBe(1);
+    });
+  });
+
+  function placeBombsAndReachEating(p1Bomb: number, p2Bomb: number): void {
+    component.selectBombsPerPlayer(1);
+    component.startSetup();
+    component.confirmHandoff();
+    component.togglePlacementCell(p1Bomb);
+    component.confirmPlacement();
+    component.confirmHandoff();
+    component.togglePlacementCell(p2Bomb);
+    component.confirmPlacement();
+  }
+
+  describe('eating', () => {
+    it('revealing a safe cell marks it safe and passes the turn', () => {
+      placeBombsAndReachEating(3, 7);
+
+      component.pickCell(0); // safe
+
+      expect(component.revealed[0]).toBe('safe');
+      expect(component.currentEater).toBe(2);
+      expect(component.phase).toBe('eating');
+    });
+
+    it('picking a bomb ends the game, sets the loser, and reveals remaining bombs', () => {
+      placeBombsAndReachEating(3, 7);
+
+      component.pickCell(3); // player 1 picks their own bomb
+
+      expect(component.phase).toBe('ended');
+      expect(component.loser).toBe(1);
+      expect(component.revealed[3]).toBe('bomb');
+      expect(component.revealed[7]).toBe('bomb'); // remaining bomb revealed too
+    });
+
+    it('ignores clicks on already-revealed cells', () => {
+      placeBombsAndReachEating(3, 7);
+
+      component.pickCell(0);
+      const eaterAfterFirstPick = component.currentEater;
+      component.pickCell(0); // already revealed, should be a no-op
+
+      expect(component.currentEater).toBe(eaterAfterFirstPick);
+    });
+
+    it('ignores picks once the game has ended', () => {
+      placeBombsAndReachEating(3, 7);
+      component.pickCell(3); // ends the game, player 1 loses
+
+      component.pickCell(0);
+      expect(component.revealed[0]).toBeNull();
+    });
+
+    it('always resolves: picking every safe cell eventually forces a bomb pick', () => {
+      placeBombsAndReachEating(3, 7);
+
+      const safeCells = [...Array(10).keys()].filter((i) => i !== 3 && i !== 7);
+      for (const cell of safeCells) {
+        if (component.phase === 'ended') {
+          break;
+        }
+        component.pickCell(cell);
+      }
+
+      // Only the two bomb cells are left unrevealed; the next pick must be a bomb.
+      expect(component.phase).toBe('eating');
+      component.pickCell(3);
+      expect(component.phase).toBe('ended');
+      expect(component.loser).not.toBeNull();
+    });
+  });
+
+  it('playAgain returns to the setup screen', () => {
+    placeBombsAndReachEating(3, 7);
+    component.pickCell(3);
+
+    component.playAgain();
+
+    expect(component.phase).toBe('setup');
+  });
+});

--- a/wongsakorn127-byjaimesjames/src/app/feature/bombGame/page/bombgame/bombgame.component.ts
+++ b/wongsakorn127-byjaimesjames/src/app/feature/bombGame/page/bombgame/bombgame.component.ts
@@ -1,0 +1,119 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ShellComponent } from '../../../../core/layout/shell/shell.component';
+
+type Phase = 'setup' | 'handoff' | 'placement' | 'eating' | 'ended';
+type Player = 1 | 2;
+type Reveal = 'safe' | 'bomb' | null;
+
+const PILE_SIZE = 10;
+
+@Component({
+  selector: 'app-bombgame',
+  standalone: true,
+  imports: [CommonModule, ShellComponent],
+  templateUrl: './bombgame.component.html',
+  styleUrl: './bombgame.component.css',
+})
+export class BombgameComponent {
+  readonly pileSize = PILE_SIZE;
+  readonly bombOptions: (1 | 2)[] = [1, 2];
+
+  bombsPerPlayer: 1 | 2 = 1;
+  phase: Phase = 'setup';
+
+  bombs: boolean[] = [];
+  revealed: Reveal[] = [];
+
+  placingPlayer: Player = 1;
+  placementSelections: number[] = [];
+
+  currentEater: Player = 1;
+  loser: Player | null = null;
+
+  selectBombsPerPlayer(count: 1 | 2): void {
+    this.bombsPerPlayer = count;
+  }
+
+  startSetup(): void {
+    this.bombs = new Array(PILE_SIZE).fill(false);
+    this.revealed = new Array(PILE_SIZE).fill(null);
+    this.placingPlayer = 1;
+    this.placementSelections = [];
+    this.loser = null;
+    this.phase = 'handoff';
+  }
+
+  confirmHandoff(): void {
+    this.placementSelections = [];
+    this.phase = 'placement';
+  }
+
+  togglePlacementCell(index: number): void {
+    const selectedPos = this.placementSelections.indexOf(index);
+    if (selectedPos !== -1) {
+      this.placementSelections.splice(selectedPos, 1);
+      return;
+    }
+    if (this.placementSelections.length >= this.bombsPerPlayer) {
+      return;
+    }
+    this.placementSelections.push(index);
+  }
+
+  isSelectedForPlacement(index: number): boolean {
+    return this.placementSelections.includes(index);
+  }
+
+  canConfirmPlacement(): boolean {
+    return this.placementSelections.length === this.bombsPerPlayer;
+  }
+
+  confirmPlacement(): void {
+    if (!this.canConfirmPlacement()) {
+      return;
+    }
+
+    for (const index of this.placementSelections) {
+      this.bombs[index] = true;
+    }
+    this.placementSelections = [];
+
+    if (this.placingPlayer === 1) {
+      this.placingPlayer = 2;
+      this.phase = 'handoff';
+    } else {
+      this.currentEater = 1;
+      this.phase = 'eating';
+    }
+  }
+
+  pickCell(index: number): void {
+    if (this.phase !== 'eating' || this.revealed[index] !== null) {
+      return;
+    }
+
+    if (this.bombs[index]) {
+      this.revealed[index] = 'bomb';
+      this.loser = this.currentEater;
+      this.revealRemainingBombs();
+      this.phase = 'ended';
+      return;
+    }
+
+    this.revealed[index] = 'safe';
+    this.currentEater = this.currentEater === 1 ? 2 : 1;
+  }
+
+  private revealRemainingBombs(): void {
+    for (let i = 0; i < PILE_SIZE; i++) {
+      if (this.bombs[i] && this.revealed[i] === null) {
+        this.revealed[i] = 'bomb';
+      }
+    }
+  }
+
+  playAgain(): void {
+    this.phase = 'setup';
+  }
+}

--- a/wongsakorn127-byjaimesjames/src/styles.css
+++ b/wongsakorn127-byjaimesjames/src/styles.css
@@ -17,6 +17,7 @@
     --color-dude-or-there: #B83CF2;
     --color-spinit-game: #7137C8;
     --color-xo-game: #FF6B4A;
+    --color-bomb-game: #16A34A;
 }
 
 /* Spin It owns the popup shell; the package only renders the color plane and hue control. */


### PR DESCRIPTION
## Summary
- New local 2-player pass-and-play game at `/bomb-game`, inspired by the "wasabi roulette" social-media trend.
- Setup screen picks bombs-per-player (1 or 2).
- Each player privately places their bombs into a single shared 10-item pile, gated by a hand-off interstitial ("Pass the device to Player X") so the other player can't see the placement.
- After both place, the eating phase is shown to both: turns alternate picking one item from the shared pile. Safe picks reveal and pass the turn; a bomb pick ends the game immediately, sets the loser, and reveals the remaining bombs.
- Overlapping bomb placements between the two players are merged silently (no error) rather than blocked.

Closes #47

## Test plan
- [x] `npm run test:ci` — 111/111 passing (new tests: placement validation, overlapping selections, safe pick, bomb pick + reveal, guaranteed resolution)
- [x] `npm run build` — passing
- [x] Verified live in browser end-to-end: Player 1 places at index 3, hand-off confirmed Player 2 cannot see that placement (pile shown fully neutral), Player 2 places at index 7, eating phase correctly resolves a safe pick then a bomb pick (correct loser, remaining bomb revealed), no title/content overlap